### PR TITLE
Implements commit log compression.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1229,13 +1229,20 @@
   </target>
     
   <target name="test-compression" depends="build-test" description="Execute unit tests with sstable compression enabled">
-      <testmacro suitename="unit" inputdir="${test.unit.src}" exclude="**/pig/*.java" timeout="${test.timeout}">
+    <property name="compressed_yaml" value="${build.test.dir}/cassandra.compressed.yaml"/>
+    <concat destfile="${compressed_yaml}">
+      <fileset file="${test.conf}/cassandra.yaml"/>
+      <fileset file="${test.conf}/commitlog_compression.yaml"/>
+    </concat>
+    <echo>Compressed config: ${compressed_yaml}</echo>
+    <testmacro suitename="unit" inputdir="${test.unit.src}" exclude="**/pig/*.java" timeout="${test.timeout}">
       <jvmarg value="-Dlegacy-sstable-root=${test.data}/legacy-sstables"/>
       <jvmarg value="-Dcorrupt-sstable-root=${test.data}/corrupt-sstables"/>
       <jvmarg value="-Dmigration-sstable-root=${test.data}/migration-sstables"/>
       <jvmarg value="-Dcassandra.test.compression=true"/>
       <jvmarg value="-Dcassandra.ring_delay_ms=1000"/>
       <jvmarg value="-Dcassandra.tolerate_sstable_size=true"/>
+      <jvmarg value="-Dcassandra.config=file:///${compressed_yaml}"/>
     </testmacro>
     <fileset dir="${test.unit.src}">
         <exclude name="**/pig/*.java" />

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -244,6 +244,13 @@ commitlog_sync_period_in_ms: 10000
 # is reasonable.
 commitlog_segment_size_in_mb: 32
 
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.
+#commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
 # any class that implements the SeedProvider interface and has a
 # constructor that takes a Map<String, String> of parameters will do.
 seed_provider:

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -251,6 +251,10 @@ commitlog_segment_size_in_mb: 32
 #     parameters:
 #         -
 
+# Specifies the number of sync threads to use for the commit log.
+# Only usable with compression.
+#commitlog_sync_threads: 1
+
 # any class that implements the SeedProvider interface and has a
 # constructor that takes a Map<String, String> of parameters will do.
 seed_provider:

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -20,12 +20,13 @@ package org.apache.cassandra.config;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
+
 import org.supercsv.io.CsvListReader;
 import org.supercsv.prefs.CsvPreference;
-
 import org.apache.cassandra.config.EncryptionOptions.ClientEncryptionOptions;
 import org.apache.cassandra.config.EncryptionOptions.ServerEncryptionOptions;
 import org.apache.cassandra.exceptions.ConfigurationException;
@@ -53,7 +54,7 @@ public class Config
     public Set<String> hinted_handoff_enabled_by_dc = Sets.newConcurrentHashSet();
     public volatile Integer max_hint_window_in_ms = 3600 * 1000; // one hour
 
-    public SeedProviderDef seed_provider;
+    public ParametrizedClass seed_provider;
     public DiskAccessMode disk_access_mode = DiskAccessMode.auto;
 
     public DiskFailurePolicy disk_failure_policy = DiskFailurePolicy.ignore;
@@ -152,6 +153,7 @@ public class Config
     public Integer commitlog_sync_period_in_ms;
     public int commitlog_segment_size_in_mb = 32;
     public int commitlog_periodic_queue_size = 1024 * FBUtilities.getAvailableProcessors();
+    public ParametrizedClass commitlog_compression;
 
     public String endpoint_snitch;
     public Boolean dynamic_snitch = true;

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.config;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -151,6 +150,7 @@ public class Config
     public CommitLogSync commitlog_sync;
     public Double commitlog_sync_batch_window_in_ms;
     public Integer commitlog_sync_period_in_ms;
+    public int commitlog_sync_threads = 1;
     public int commitlog_segment_size_in_mb = 32;
     public int commitlog_periodic_queue_size = 1024 * FBUtilities.getAvailableProcessors();
     public ParametrizedClass commitlog_compression;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -1068,6 +1068,11 @@ public class DatabaseDescriptor
         return conf.commitlog_directory;
     }
 
+    public static ParametrizedClass getCommitLogCompression()
+    {
+        return conf.commitlog_compression;
+    }
+
     public static int getTombstoneWarnThreshold()
     {
         return conf.tombstone_warn_threshold;

--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -189,6 +189,12 @@ public class DatabaseDescriptor
             logger.debug("Syncing log with a period of {}", conf.commitlog_sync_period_in_ms);
         }
 
+        if (conf.commitlog_sync_threads < 1)
+            throw new ConfigurationException("commitlog_sync_threads must be a positive integer.");
+
+        if (conf.commitlog_compression == null && conf.commitlog_sync_threads > 1)
+            throw new ConfigurationException("commitlog_sync_threads can only be used when compression is enabled.");
+
         if (conf.commitlog_total_space_in_mb == null)
             conf.commitlog_total_space_in_mb = hasLargeAddressSpace() ? 8192 : 32;
 
@@ -1071,6 +1077,11 @@ public class DatabaseDescriptor
     public static ParametrizedClass getCommitLogCompression()
     {
         return conf.commitlog_compression;
+    }
+
+    public static int getCommitLogSyncThreadCount()
+    {
+        return conf.commitlog_sync_threads;
     }
 
     public static int getTombstoneWarnThreshold()

--- a/src/java/org/apache/cassandra/config/ParametrizedClass.java
+++ b/src/java/org/apache/cassandra/config/ParametrizedClass.java
@@ -21,15 +21,40 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Objects;
 
-public class SeedProviderDef
+public class ParametrizedClass
 {
     public String class_name;
     public Map<String, String> parameters;
 
-    public SeedProviderDef(LinkedHashMap<String, ?> p)
+    public ParametrizedClass(String class_name, Map<String, String> parameters)
     {
-        class_name = (String)p.get("class_name");
-        parameters = (Map<String, String>)((List)p.get("parameters")).get(0);
+        this.class_name = class_name;
+        this.parameters = parameters;
+    }
+
+    @SuppressWarnings("unchecked")
+    public ParametrizedClass(LinkedHashMap<String, ?> p)
+    {
+        this((String)p.get("class_name"),
+                p.containsKey("parameters") ? (Map<String, String>)((List<?>)p.get("parameters")).get(0) : null);
+    }
+
+    @Override
+    public boolean equals(Object that)
+    {
+        return that instanceof ParametrizedClass && equals((ParametrizedClass) that);
+    }
+
+    public boolean equals(ParametrizedClass that)
+    {
+        return Objects.equal(class_name, that.class_name) && Objects.equal(parameters, that.parameters);
+    }
+
+    @Override
+    public String toString()
+    {
+        return class_name + (parameters == null ? "" : parameters.toString());
     }
 }

--- a/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
+++ b/src/java/org/apache/cassandra/config/YamlConfigurationLoader.java
@@ -104,7 +104,7 @@ public class YamlConfigurationLoader implements ConfigurationLoader
             logConfig(configBytes);
             
             org.yaml.snakeyaml.constructor.Constructor constructor = new org.yaml.snakeyaml.constructor.Constructor(Config.class);
-            TypeDescription seedDesc = new TypeDescription(SeedProviderDef.class);
+            TypeDescription seedDesc = new TypeDescription(ParametrizedClass.class);
             seedDesc.putMapPropertyType("parameters", String.class, String.class);
             constructor.addTypeDescription(seedDesc);
             MissingPropertiesChecker propertiesChecker = new MissingPropertiesChecker();

--- a/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
+++ b/src/java/org/apache/cassandra/db/commitlog/AbstractCommitLogService.java
@@ -17,10 +17,15 @@
  */
 package org.apache.cassandra.db.commitlog;
 
+import org.apache.cassandra.concurrent.NamedThreadFactory;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.utils.concurrent.WaitQueue;
+
 import org.slf4j.*;
 
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,11 +36,10 @@ public abstract class AbstractCommitLogService
     // how often should we log syngs that lag behind our desired period
     private static final long LAG_REPORT_INTERVAL = TimeUnit.MINUTES.toMillis(5);
 
-    private final Thread thread;
-    private volatile boolean shutdown = false;
-
-    // all Allocations written before this time will be synced
-    protected volatile long lastSyncedAt = System.currentTimeMillis();
+    // all Allocations written before this time are synced.
+    // Note: this number might jump back once in a while, but will eventually increase past any point in time.
+    // If a jump does occur, mutations started before both the higher and lower number are synced at that time.
+    protected volatile long approximateSyncedAt = System.currentTimeMillis();
 
     // counts of total written, and pending, log messages
     private final AtomicLong written = new AtomicLong(0);
@@ -43,9 +47,18 @@ public abstract class AbstractCommitLogService
 
     // signal that writers can wait on to be notified of a completed sync
     protected final WaitQueue syncComplete = new WaitQueue();
-    private final Semaphore haveWork = new Semaphore(1);
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractCommitLogService.class);
+    private final ScheduledExecutorService executor;
+    private final Runnable runnable;
+
+    long firstLagAt = 0;
+    long totalSyncDuration = 0; // total time spent syncing since firstLagAt
+    long syncExceededIntervalBy = 0; // time that syncs exceeded pollInterval since firstLagAt
+    int lagCount = 0;
+    int syncCount = 0;
+    
+    volatile boolean shutdown = false;
 
     /**
      * CommitLogService provides a fsync service for Allocations, fulfilling either the
@@ -58,89 +71,61 @@ public abstract class AbstractCommitLogService
         if (pollIntervalMillis < 1)
             throw new IllegalArgumentException(String.format("Commit log flush interval must be positive: %dms", pollIntervalMillis));
 
-        Runnable runnable = new Runnable()
+        runnable = new Runnable()
         {
             public void run()
             {
-                long firstLagAt = 0;
-                long totalSyncDuration = 0; // total time spent syncing since firstLagAt
-                long syncExceededIntervalBy = 0; // time that syncs exceeded pollInterval since firstLagAt
-                int lagCount = 0;
-                int syncCount = 0;
-
-                boolean run = true;
-                while (run)
+                try
                 {
-                    try
+                    // always run once after shutdown signalled
+                    if (shutdown)
+                        executor.shutdown();
+
+                    // sync and signal
+                    long syncStarted = System.currentTimeMillis();
+                    commitLog.sync(shutdown);
+                    // This might overwrite a higher number put by another thread. This is not a problem
+                    // as to reach this point the other thread must have waited for our writes to complete.
+                    approximateSyncedAt = syncStarted;
+                    syncComplete.signalAll();
+
+
+                    // sleep any time we have left before the next one is due
+                    long now = System.currentTimeMillis();
+                    long sleep = syncStarted + pollIntervalMillis - now;
+                    if (sleep < 0)
                     {
-                        // always run once after shutdown signalled
-                        run = !shutdown;
-
-                        // sync and signal
-                        long syncStarted = System.currentTimeMillis();
-                        commitLog.sync(shutdown);
-                        lastSyncedAt = syncStarted;
-                        syncComplete.signalAll();
-
-
-                        // sleep any time we have left before the next one is due
-                        long now = System.currentTimeMillis();
-                        long sleep = syncStarted + pollIntervalMillis - now;
-                        if (sleep < 0)
+                        // if we have lagged noticeably, update our lag counter
+                        if (firstLagAt == 0)
                         {
-                            // if we have lagged noticeably, update our lag counter
-                            if (firstLagAt == 0)
-                            {
-                                firstLagAt = now;
-                                totalSyncDuration = syncExceededIntervalBy = syncCount = lagCount = 0;
-                            }
-                            syncExceededIntervalBy -= sleep;
-                            lagCount++;
+                            firstLagAt = now;
+                            totalSyncDuration = syncExceededIntervalBy = syncCount = lagCount = 0;
                         }
-                        syncCount++;
-                        totalSyncDuration += now - syncStarted;
-
-                        if (firstLagAt > 0 && now - firstLagAt >= LAG_REPORT_INTERVAL)
-                        {
-                            logger.warn(String.format("Out of %d commit log syncs over the past %ds with average duration of %.2fms, %d have exceeded the configured commit interval by an average of %.2fms",
-                                                      syncCount, (now - firstLagAt) / 1000, (double) totalSyncDuration / syncCount, lagCount, (double) syncExceededIntervalBy / lagCount));
-                            firstLagAt = 0;
-                        }
-
-                        // if we have lagged this round, we probably have work to do already so we don't sleep
-                        if (sleep < 0 || !run)
-                            continue;
-
-                        try
-                        {
-                            haveWork.tryAcquire(sleep, TimeUnit.MILLISECONDS);
-                        }
-                        catch (InterruptedException e)
-                        {
-                            throw new AssertionError();
-                        }
+                        syncExceededIntervalBy -= sleep;
+                        lagCount++;
                     }
-                    catch (Throwable t)
+                    syncCount++;
+                    totalSyncDuration += now - syncStarted;
+
+                    if (firstLagAt > 0 && now - firstLagAt >= LAG_REPORT_INTERVAL)
                     {
-                        if (!CommitLog.handleCommitError("Failed to persist commits to disk", t))
-                            break;
-
-                        // sleep for full poll-interval after an error, so we don't spam the log file
-                        try
-                        {
-                            haveWork.tryAcquire(pollIntervalMillis, TimeUnit.MILLISECONDS);
-                        }
-                        catch (InterruptedException e)
-                        {
-                            throw new AssertionError();
-                        }
+                        logger.warn(String.format("Out of %d commit log syncs over the past %ds with average duration of %.2fms, %d have exceeded the configured commit interval by an average of %.2fms",
+                                                  syncCount, (now - firstLagAt) / 1000, (double) totalSyncDuration / syncCount, lagCount, (double) syncExceededIntervalBy / lagCount));
+                        firstLagAt = 0;
                     }
+                }
+                catch (Throwable t)
+                {
+                    if (!CommitLog.handleCommitError("Failed to persist commits to disk", t))
+                        executor.shutdown();
                 }
             }
         };
 
-        thread = new Thread(runnable, name);
-        thread.start();
+        int threadCount = DatabaseDescriptor.getCommitLogSyncThreadCount();
+        executor = Executors.newScheduledThreadPool(threadCount, new NamedThreadFactory("commit-log-service"));
+        for (int i=0; i<threadCount; ++i)
+            executor.scheduleAtFixedRate(runnable, pollIntervalMillis * i, pollIntervalMillis * threadCount, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -157,22 +142,20 @@ public abstract class AbstractCommitLogService
     /**
      * Sync immediately, but don't block for the sync to cmplete
      */
-    public WaitQueue.Signal requestExtraSync()
+    public Future<?> requestExtraSync()
     {
-        WaitQueue.Signal signal = syncComplete.register();
-        haveWork.release(1);
-        return signal;
+        return executor.submit(runnable);
     }
 
     public void shutdown()
     {
         shutdown = true;
-        haveWork.release(1);
+        requestExtraSync();
     }
 
     public void awaitTermination() throws InterruptedException
     {
-        thread.join();
+        executor.awaitTermination(3600, TimeUnit.SECONDS);
     }
 
     public long getCompletedTasks()

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLog.java
@@ -30,8 +30,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.ParametrizedClass;
 import org.apache.cassandra.db.*;
+import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.compress.CompressionParameters;
+import org.apache.cassandra.io.compress.ICompressor;
 import org.apache.cassandra.io.util.DataOutputByteBuffer;
 import org.apache.cassandra.metrics.CommitLogMetrics;
 import org.apache.cassandra.net.MessagingService;
@@ -58,6 +62,20 @@ public class CommitLog implements CommitLogMBean
     public final CommitLogArchiver archiver = new CommitLogArchiver();
     final CommitLogMetrics metrics;
     final AbstractCommitLogService executor;
+
+    static final ICompressor compressor;
+    static {
+        try
+        {
+            ParametrizedClass compressionClass = DatabaseDescriptor.getCommitLogCompression();
+            compressor = compressionClass != null ? CompressionParameters.createCompressor(compressionClass) : null;
+        }
+        catch (ConfigurationException e)
+        {
+            logger.error("Fatal configuration error", e);
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     private CommitLog()
     {

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogArchiver.java
@@ -32,10 +32,11 @@ import java.util.concurrent.*;
 
 import org.apache.cassandra.concurrent.JMXEnabledThreadPoolExecutor;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.io.compress.CompressionParameters;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.utils.WrappedRunnable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -166,7 +167,7 @@ public class CommitLogArchiver
                 CommitLogDescriptor descriptor;
                 if (fromHeader == null && fromName == null)
                     throw new IllegalStateException("Cannot safely construct descriptor for segment, either from its name or its header: " + fromFile.getPath());
-                else if (fromHeader != null && fromName != null && !fromHeader.equals(fromName))
+                else if (fromHeader != null && fromName != null && !fromHeader.equalsIgnoringCompression(fromName))
                     throw new IllegalStateException(String.format("Cannot safely construct descriptor for segment, as name and header descriptors do not match (%s vs %s): %s", fromHeader, fromName, fromFile.getPath()));
                 else if (fromName != null && fromHeader == null && fromName.version >= CommitLogDescriptor.VERSION_21)
                     throw new IllegalStateException("Cannot safely construct descriptor for segment, as name descriptor implies a version that should contain a header descriptor, but that descriptor could not be read: " + fromFile.getPath());
@@ -174,8 +175,19 @@ public class CommitLogArchiver
                     descriptor = fromHeader;
                 else descriptor = fromName;
 
-                if (descriptor.version > CommitLogDescriptor.VERSION_21)
+                if (descriptor.version > CommitLogDescriptor.VERSION_22)
                     throw new IllegalStateException("Unsupported commit log version: " + descriptor.version);
+
+                if (descriptor.compression != null) {
+                    try
+                    {
+                        CompressionParameters.createCompressor(descriptor.compression);
+                    }
+                    catch (ConfigurationException e)
+                    {
+                        throw new IllegalStateException("Unknown compression", e);
+                    }
+                }
 
                 File toFile = new File(DatabaseDescriptor.getCommitLogLocation(), descriptor.fileName());
                 if (toFile.exists())

--- a/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentManager.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CommitLogSegmentManager.java
@@ -393,7 +393,7 @@ public class CommitLogSegmentManager
         {
             public CommitLogSegment call()
             {
-                return new CommitLogSegment(file.getPath());
+                return CommitLogSegment.createSegment(file.getPath());
             }
         });
     }

--- a/src/java/org/apache/cassandra/db/commitlog/CompressedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/CompressedSegment.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.commitlog;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.compress.ICompressor.WrappedArray;
+import org.apache.cassandra.io.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * A single commit log file on disk. Manages creation of the file and writing mutations to disk,
+ * as well as tracking the last mutation position of any "dirty" CFs covered by the segment file. Segment
+ * files are initially allocated to a fixed size and can grow to accomidate a larger value if necessary.
+ */
+public class CompressedSegment extends CommitLogSegment
+{
+    private static final Logger logger = LoggerFactory.getLogger(CompressedSegment.class);
+
+    private final FileChannel channel;
+    WrappedArray compressedArray = new WrappedArray(new byte[1024]);
+    ByteBuffer compressedBuffer = ByteBuffer.wrap(compressedArray.buffer);
+    
+    static final int COMPRESSED_MARKER_SIZE = SYNC_MARKER_SIZE + 4;
+
+    /**
+     * Constructs a new segment file.
+     *
+     * @param filePath  if not null, recycles the existing file by renaming it and truncating it to CommitLog.SEGMENT_SIZE.
+     */
+    CompressedSegment(String filePath)
+    {
+        super(filePath);
+        try
+        {
+            channel = logFileAccessor.getChannel();
+            channel.write((ByteBuffer) buffer.duplicate().flip());
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    void recycleFile(String filePath)
+    {
+        File oldFile = new File(filePath);
+
+        if (oldFile.exists())
+        {
+            logger.debug("Deleting old CommitLog segment {}", filePath);
+            FileUtils.deleteWithConfirm(oldFile);
+        }
+    }
+
+    ByteBuffer createBuffer()
+    {
+        return ByteBuffer.allocate(DatabaseDescriptor.getCommitLogSegmentSize());
+    }
+
+    @Override
+    synchronized int write(int lastSyncedOffset, int nextMarker, boolean close)
+    {
+        try {
+            int contentStart = lastSyncedOffset + SYNC_MARKER_SIZE;
+            int length = nextMarker - contentStart;
+            if (length == 0)
+                // No content to write, but we can still advance in the input buffer.
+                return nextMarker;
+
+            int compressedLength = CommitLog.compressor.initialCompressedBufferLength(length);
+            if (compressedArray.buffer.length < compressedLength + COMPRESSED_MARKER_SIZE) {
+                compressedArray.buffer = new byte[compressedLength + COMPRESSED_MARKER_SIZE];
+                compressedBuffer = ByteBuffer.wrap(compressedArray.buffer);
+            }
+            
+            compressedLength = CommitLog.compressor.compress(buffer.array(), buffer.arrayOffset() + contentStart, length, compressedArray, COMPRESSED_MARKER_SIZE);
+            compressedBuffer.position(0);
+            compressedBuffer.limit(COMPRESSED_MARKER_SIZE + compressedLength);
+            writeSyncMarker(compressedBuffer, 0, (int) channel.position(), (int) channel.position() + compressedBuffer.remaining());
+            compressedBuffer.putInt(SYNC_MARKER_SIZE, length);
+            channel.write(compressedBuffer);
+            channel.force(true);
+            if (close)
+                close();
+            return nextMarker;
+        }
+        catch (Exception e)
+        {
+            throw new FSWriteError(e, getPath());
+        }
+    }
+
+    /**
+     * Recycle processes an unneeded segment file for reuse.
+     * Synchronized to avoid breaking any in-progress sync.
+     *
+     * @return a new CommitLogSegment representing the newly reusable segment.
+     */
+    synchronized CompressedSegment recycle()
+    {
+        // The file will be immediately deleted, don't try to write any data.
+        close();
+        return new CompressedSegment(getPath());
+    }
+
+
+    @Override
+    void close()
+    {
+        super.close();
+        buffer = null;
+        compressedArray = null;
+        compressedBuffer = null;
+    }
+
+}

--- a/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.db.commitlog;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.io.FSWriteError;
+import org.apache.cassandra.io.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * A single commit log file on disk. Manages creation of the file and writing mutations to disk,
+ * as well as tracking the last mutation position of any "dirty" CFs covered by the segment file. Segment
+ * files are initially allocated to a fixed size and can grow to accomidate a larger value if necessary.
+ */
+public class MemoryMappedSegment extends CommitLogSegment
+{
+    private static final Logger logger = LoggerFactory.getLogger(MemoryMappedSegment.class);
+
+    private MappedByteBuffer mappedBuffer;
+
+    /**
+     * Constructs a new segment file.
+     *
+     * @param filePath  if not null, recycles the existing file by renaming it and truncating it to CommitLog.SEGMENT_SIZE.
+     */
+    MemoryMappedSegment(String filePath)
+    {
+        super(filePath);
+    }
+
+    void recycleFile(String filePath)
+    {
+        File oldFile = new File(filePath);
+
+        if (oldFile.exists())
+        {
+            logger.debug("Re-using discarded CommitLog segment for {} from {}", id, filePath);
+            if (!oldFile.renameTo(logFile))
+                throw new FSWriteError(new IOException("Rename from " + filePath + " to " + id + " failed"), filePath);
+        } else {
+            logger.debug("Creating new commit log segment {}", logFile.getPath());
+        }
+    }
+
+    ByteBuffer createBuffer()
+    {
+        try
+        {
+            // Map the segment, extending or truncating it to the standard segment size.
+            // (We may have restarted after a segment size configuration change, leaving "incorrectly"
+            // sized segments on disk.)
+            logFileAccessor.setLength(DatabaseDescriptor.getCommitLogSegmentSize());
+            mappedBuffer = logFileAccessor.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, DatabaseDescriptor.getCommitLogSegmentSize());
+            return mappedBuffer;
+        }
+        catch (IOException e)
+        {
+            throw new FSWriteError(e, logFile);
+        }
+    }
+
+    @Override
+    synchronized int write(int lastSyncedOffset, int nextMarker, boolean close)
+    {
+        try {
+            // actually perform the sync and signal those waiting for it
+            mappedBuffer.force();
+        }
+        catch (Exception e) // MappedByteBuffer.force() does not declare IOException but can actually throw it
+        {
+            throw new FSWriteError(e, getPath());
+        }
+        if (close) {
+            nextMarker = mappedBuffer.capacity();
+            close();
+        }
+        return nextMarker;
+    }
+
+    /**
+     * Recycle processes an unneeded segment file for reuse.
+     *
+     * @return a new CommitLogSegment representing the newly reusable segment.
+     */
+    MemoryMappedSegment recycle()
+    {
+        try
+        {
+            sync();
+        }
+        catch (FSWriteError e)
+        {
+            logger.error("I/O error flushing {} {}", this, e.getMessage());
+            throw e;
+        }
+
+        close();
+
+        return new MemoryMappedSegment(getPath());
+    }
+
+    @Override
+    void close()
+    {
+        if (FileUtils.isCleanerAvailable())
+            FileUtils.clean(mappedBuffer);
+        super.close();
+    }
+}

--- a/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
+++ b/src/java/org/apache/cassandra/db/commitlog/MemoryMappedSegment.java
@@ -86,6 +86,10 @@ public class MemoryMappedSegment extends CommitLogSegment
     @Override
     void write(int startMarker, int nextMarker)
     {
+        // write previous sync marker to point to next sync marker
+        // we don't chain the crcs here to ensure this method is idempotent if it fails
+        writeSyncMarker(buffer, startMarker, startMarker, nextMarker);
+
         try {
             // actually perform the sync and signal those waiting for it
             mappedBuffer.force();

--- a/src/java/org/apache/cassandra/db/commitlog/PeriodicCommitLogService.java
+++ b/src/java/org/apache/cassandra/db/commitlog/PeriodicCommitLogService.java
@@ -54,6 +54,6 @@ class PeriodicCommitLogService extends AbstractCommitLogService
      */
     private boolean waitForSyncToCatchUp(long started)
     {
-        return started > lastSyncedAt + blockWhenSyncLagsMillis;
+        return started > approximateSyncedAt + blockWhenSyncLagsMillis;
     }
 }

--- a/src/java/org/apache/cassandra/io/compress/CompressionParameters.java
+++ b/src/java/org/apache/cassandra/io/compress/CompressionParameters.java
@@ -29,10 +29,11 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.config.ParametrizedClass;
 import org.apache.cassandra.db.TypeSizes;
 import org.apache.cassandra.io.IVersionedSerializer;
 import org.apache.cassandra.io.util.DataOutputPlus;
@@ -137,7 +138,7 @@ public class CompressionParameters
         return chunkLength == null ? DEFAULT_CHUNK_LENGTH : chunkLength;
     }
 
-    private static Class<? extends ICompressor> parseCompressorClass(String className) throws ConfigurationException
+    private static Class<?> parseCompressorClass(String className) throws ConfigurationException
     {
         if (className == null || className.isEmpty())
             return null;
@@ -145,7 +146,7 @@ public class CompressionParameters
         className = className.contains(".") ? className : "org.apache.cassandra.io.compress." + className;
         try
         {
-            return (Class<? extends ICompressor>)Class.forName(className);
+            return Class.forName(className);
         }
         catch (Exception e)
         {
@@ -153,7 +154,7 @@ public class CompressionParameters
         }
     }
 
-    private static ICompressor createCompressor(Class<? extends ICompressor> compressorClass, Map<String, String> compressionOptions) throws ConfigurationException
+    private static ICompressor createCompressor(Class<?> compressorClass, Map<String, String> compressionOptions) throws ConfigurationException
     {
         if (compressorClass == null)
         {
@@ -197,6 +198,10 @@ public class CompressionParameters
         {
             throw new ConfigurationException("Cannot initialize class " + compressorClass.getName());
         }
+    }
+
+    public static ICompressor createCompressor(ParametrizedClass compression) throws ConfigurationException {
+        return createCompressor(parseCompressorClass(compression.class_name), copyOptions(compression.parameters));
     }
 
     private static Map<String, String> copyOptions(Map<? extends CharSequence, ? extends CharSequence> co)

--- a/src/java/org/apache/cassandra/io/util/ByteBufferDataInput.java
+++ b/src/java/org/apache/cassandra/io/util/ByteBufferDataInput.java
@@ -19,19 +19,18 @@ package org.apache.cassandra.io.util;
 
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
 import org.apache.cassandra.utils.ByteBufferUtil;
 
-public class MappedFileDataInput extends AbstractDataInput implements FileDataInput, DataInput
+public class ByteBufferDataInput extends AbstractDataInput implements FileDataInput, DataInput
 {
-    private final MappedByteBuffer buffer;
+    private final ByteBuffer buffer;
     private final String filename;
     private final long segmentOffset;
     private int position;
 
-    public MappedFileDataInput(FileInputStream stream, String filename, long segmentOffset, int position) throws IOException
+    public ByteBufferDataInput(FileInputStream stream, String filename, long segmentOffset, int position) throws IOException
     {
         FileChannel channel = stream.getChannel();
         buffer = channel.map(FileChannel.MapMode.READ_ONLY, position, channel.size());
@@ -40,7 +39,7 @@ public class MappedFileDataInput extends AbstractDataInput implements FileDataIn
         this.position = position;
     }
 
-    public MappedFileDataInput(MappedByteBuffer buffer, String filename, long segmentOffset, int position)
+    public ByteBufferDataInput(ByteBuffer buffer, String filename, long segmentOffset, int position)
     {
         assert buffer != null;
         this.buffer = buffer;
@@ -65,12 +64,14 @@ public class MappedFileDataInput extends AbstractDataInput implements FileDataIn
         return segmentOffset + position;
     }
 
-    protected long getPosition()
+    @Override
+    public long getPosition()
     {
         return segmentOffset + position;
     }
 
-    protected long getPositionLimit()
+    @Override
+    public long getPositionLimit()
     {
         return segmentOffset + buffer.capacity();
     }
@@ -156,9 +157,10 @@ public class MappedFileDataInput extends AbstractDataInput implements FileDataIn
     }
 
     @Override
-    public final void readFully(byte[] buffer, int offset, int count) throws IOException
+    public final void readFully(byte[] bytes, int offset, int count) throws IOException
     {
-        throw new UnsupportedOperationException("use readBytes instead");
+        ByteBufferUtil.arrayCopy(buffer, buffer.position() + position, bytes, offset, count);
+        position += count;
     }
 
     private static class MappedFileDataInputMark implements FileMark

--- a/src/java/org/apache/cassandra/io/util/MmappedSegmentedFile.java
+++ b/src/java/org/apache/cassandra/io/util/MmappedSegmentedFile.java
@@ -73,7 +73,7 @@ public class MmappedSegmentedFile extends SegmentedFile
         if (segment.right != null)
         {
             // segment is mmap'd
-            return new MappedFileDataInput(segment.right, path, segment.left, (int) (position - segment.left));
+            return new ByteBufferDataInput(segment.right, path, segment.left, (int) (position - segment.left));
         }
 
         // not mmap'd: open a braf covering the segment

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -7,6 +7,7 @@ memtable_allocation_type: offheap_objects
 commitlog_sync: batch
 commitlog_sync_batch_window_in_ms: 1.0
 commitlog_segment_size_in_mb: 5
+commitlog_directory: build/test/cassandra/commitlog
 partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
 listen_address: 127.0.0.1
 storage_port: 7010
@@ -14,7 +15,6 @@ rpc_port: 9170
 start_native_transport: true
 native_transport_port: 9042
 column_index_size_in_kb: 4
-commitlog_directory: build/test/cassandra/commitlog
 saved_caches_directory: build/test/cassandra/saved_caches
 data_file_directories:
     - build/test/cassandra/data

--- a/test/conf/commitlog_compression.yaml
+++ b/test/conf/commitlog_compression.yaml
@@ -1,0 +1,2 @@
+commitlog_compression:
+    - class_name: LZ4Compressor

--- a/test/conf/commitlog_compression.yaml
+++ b/test/conf/commitlog_compression.yaml
@@ -1,2 +1,3 @@
 commitlog_compression:
     - class_name: LZ4Compressor
+commitlog_sync_threads: 4

--- a/test/long/org/apache/cassandra/db/commitlog/ComitLogStress.java
+++ b/test/long/org/apache/cassandra/db/commitlog/ComitLogStress.java
@@ -48,7 +48,7 @@ public class ComitLogStress
             System.out.println("Setting num threads to: " + NUM_THREADS);
         }
         ExecutorService executor = new JMXEnabledThreadPoolExecutor(NUM_THREADS, NUM_THREADS, 60,
-                TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(10 * NUM_THREADS), new NamedThreadFactory(""), "");
+                TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(10 * NUM_THREADS), new NamedThreadFactory("Stress"), "");
         ScheduledExecutorService scheduled = Executors.newScheduledThreadPool(1);
 
         org.apache.cassandra.SchemaLoader.loadSchema();
@@ -86,10 +86,12 @@ public class ComitLogStress
         public void run() {
             String ks = "Keyspace1";
             ByteBuffer key = ByteBufferUtil.bytes(keyString);
-            Mutation mutation = new Mutation(ks, key);
-            mutation.add("Standard1", Util.cellname("name"), ByteBufferUtil.bytes("value"),
-                    System.currentTimeMillis());
-            CommitLog.instance.add(mutation);
+            for (int i=0; i<100; ++i) {
+                Mutation mutation = new Mutation(ks, key);
+                mutation.add("Standard1", Util.cellname("name"), ByteBufferUtil.bytes("value" + i),
+                        System.currentTimeMillis());
+                CommitLog.instance.add(mutation);
+            }
         }
     }
 }


### PR DESCRIPTION
Provides two implementations of commit log segments, one matching the
previous memory-mapped writing method for uncompressed logs and one
that uses in-memory buffers and compresses sections between sync markers
before writing to the log. Replay is changed to decompresses these sections
and keep track of the uncompressed position to correctly identify the replay
position.

The compression class and parameters are specified in cassandra.yaml and
stored in the commit log descriptor, which can now vary in size.

Tested by the test-compression target, which now enables LZ4Compression
of commit logs in addition to compression for SSTables.
