### PR TITLE
CNDB-15669: implement mayHaveContent metadata flag

### DIFF
--- a/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
@@ -96,7 +96,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     T collectedContent;
 
     private long currentPosition;
-    private boolean positionCollected;
 
     <I> CollectionMergeCursor(Trie.CollectionMergeResolver<T> resolver, Direction direction, Collection<I> inputs, IntFunction<C[]> cursorArrayConstructor, BiFunction<I, Direction, C> extractor)
     {
@@ -117,8 +116,8 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
             ++i;
         }
 
-        // The cursors are all currently positioned on the root and thus in valid heap order.
-        assert Arrays.stream(heap).allMatch(x -> equalCursor(head, x));
+        // Initialize currentPosition since encodedPosition() now returns it directly
+        collectAndCachePosition();
     }
 
     /// Interface for internal operations that can be applied to selected top elements of the heap.
@@ -126,7 +125,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     {
         void apply(CollectionMergeCursor<T, C> self, C cursor, int index);
 
-        default boolean shouldContinueWithChild(C child, C head)
+        default boolean shouldContinueWithChild(CollectionMergeCursor<T, C> self, C child, C head)
         {
             return equalCursor(child, head);
         }
@@ -203,7 +202,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         if (index >= heap.length)
             return;
         C item = heap[index];
-        if (!action.shouldContinueWithChild(item, head))
+        if (!action.shouldContinueWithChild(this, item, head))
             return;
 
         // If the children are at the same position, they also need advancing and their subheap
@@ -215,6 +214,57 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         // subheaps and combine them on processing the parent.
         action.apply(this, item, index);
     }
+
+    /// Collects and caches the current position by unioning flags from all cursors at the same position.
+    /// This is called after advancing to ensure the position is always up-to-date.
+    private long collectAndCachePosition()
+    {
+        long pos = head.encodedPosition();
+        if (Cursor.isExhausted(pos) || !branchHasMultipleSources())
+        {
+            currentPosition = pos;
+            return currentPosition;
+        }
+
+        // Returns head's position with flags unioned from all cursors at the same position,
+        // since multiple sources may each contribute flags (e.g. MAY_HAVE_CONTENT_BIT) that
+        // the head alone would not reflect.
+
+        // Optimization: if the head already has all flags set, no need to walk the heap
+        if ((pos & Cursor.FLAGS_MASK) == Cursor.FLAGS_MASK)
+        {
+            currentPosition = pos;
+            return currentPosition;
+        }
+
+        currentPosition = pos;
+
+        // Walk the heap to collect flags from all equal cursors, stopping early if all flags are collected
+        applyToSelectedElementsInHeap(FLAG_COLLECTOR, 0);
+
+        // Position bits must match for all selected cursors, so we don't need unionFlags
+        return currentPosition;
+    }
+
+    /// HeapOp to collect flags from heap cursors, with early termination when all flags are collected
+    private static class FlagCollector<T, C extends Cursor<T>> implements HeapOp<T, C>
+    {
+        @Override
+        public void apply(CollectionMergeCursor<T, C> self, C cursor, int index)
+        {
+            self.currentPosition |= cursor.encodedPosition();
+        }
+
+        @Override
+        public boolean shouldContinueWithChild(CollectionMergeCursor<T, C> self, C child, C head)
+        {
+            // Continue only if cursors are equal AND we haven't collected all flags yet
+            return equalCursor(child, head) && (self.currentPosition & Cursor.FLAGS_MASK) != Cursor.FLAGS_MASK;
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static final HeapOp FLAG_COLLECTOR = new FlagCollector();
 
     /// Push the given state down in the heap from the given index until it finds its proper place among
     /// the subheap rooted at that position.
@@ -249,7 +299,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         if (cmp < 0)
         {
             currentPosition = headPosition;
-            positionCollected = true;
             return headPosition;   // head is still smallest
         }
 
@@ -260,7 +309,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
             head = heap[0];
             heapifyDown(newHeap0, 0);
         }
-        return encodedPosition();
+        return collectAndCachePosition();
     }
 
     boolean branchHasMultipleSources()
@@ -277,7 +326,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     public long advance()
     {
         contentCollected = false;
-        positionCollected = false;
         return doAdvance();
     }
 
@@ -291,7 +339,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     public long advanceMultiple(TransitionsReceiver receiver)
     {
         contentCollected = false;
-        positionCollected = false;
         // If the current position is present in just one cursor, we can safely descend multiple levels within
         // its branch as no one of the other tries has content for it.
         if (branchHasMultipleSources())
@@ -311,7 +358,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         class SkipTo implements AdvancingHeapOp<T, C>
         {
             @Override
-            public boolean shouldContinueWithChild(C child, C head)
+            public boolean shouldContinueWithChild(CollectionMergeCursor<T, C> self, C child, C head)
             {
                 // When the requested position descends, the implicit prefix bytes are those of the head cursor,
                 // and thus we need to check against that if it is a match.
@@ -331,7 +378,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         }
 
         contentCollected = false;
-        positionCollected = false;
         applyToSelectedElementsInHeap(new SkipTo(), 0);
         return maybeSwapHead(head.skipTo(encodedSkipPosition));
     }
@@ -339,24 +385,6 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     @Override
     public long encodedPosition()
     {
-        if (!positionCollected)
-        {
-            long pos = head.encodedPosition();
-            if (Cursor.isExhausted(pos) || !branchHasMultipleSources())
-                currentPosition = pos;
-            else
-            {
-                // Returns head's position with flags unioned from all cursors at the same position,
-                // since multiple sources may each contribute flags (e.g. MAY_HAVE_CONTENT_BIT) that
-                // the head alone would not reflect.
-                currentPosition = pos;
-                applyToSelectedElementsInHeap((self, cursor, index) -> {
-                    currentPosition |= cursor.encodedPosition();
-                }, 0);
-                currentPosition = Cursor.unionFlags(pos, currentPosition, Cursor.FLAGS_MASK);
-            }
-            positionCollected = true;
-        }
         return currentPosition;
     }
 

--- a/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
@@ -117,7 +117,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         }
 
         // Initialize currentPosition since encodedPosition() now returns it directly
-        collectAndCachePosition();
+        collectAndCachePositionFlags();
     }
 
     /// Interface for internal operations that can be applied to selected top elements of the heap.
@@ -217,7 +217,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
 
     /// Collects and caches the current position by unioning flags from all cursors at the same position.
     /// This is called after advancing to ensure the position is always up-to-date.
-    private long collectAndCachePosition()
+    private long collectAndCachePositionFlags()
     {
         long pos = head.encodedPosition();
         if (Cursor.isExhausted(pos) || !branchHasMultipleSources())
@@ -226,12 +226,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
             return currentPosition;
         }
 
-        // Returns head's position with flags unioned from all cursors at the same position,
-        // since multiple sources may each contribute flags (e.g. MAY_HAVE_CONTENT_BIT) that
-        // the head alone would not reflect.
-
-        // Optimization: if the head already has all flags set, no need to walk the heap
-        if ((pos & Cursor.FLAGS_MASK) == Cursor.FLAGS_MASK)
+        if ((pos & Cursor.MAY_HAVE_CONTENT_BIT) == Cursor.MAY_HAVE_CONTENT_BIT)
         {
             currentPosition = pos;
             return currentPosition;
@@ -258,8 +253,8 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         @Override
         public boolean shouldContinueWithChild(CollectionMergeCursor<T, C> self, C child, C head)
         {
-            // Continue only if cursors are equal AND we haven't collected all flags yet
-            return equalCursor(child, head) && (self.currentPosition & Cursor.FLAGS_MASK) != Cursor.FLAGS_MASK;
+            // Continue only if equal AND the content flag is not yet collected.
+            return equalCursor(child, head) && (self.currentPosition & Cursor.MAY_HAVE_CONTENT_BIT) == 0;
         }
     }
 
@@ -309,7 +304,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
             head = heap[0];
             heapifyDown(newHeap0, 0);
         }
-        return collectAndCachePosition();
+        return collectAndCachePositionFlags();
     }
 
     boolean branchHasMultipleSources()

--- a/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/CollectionMergeCursor.java
@@ -95,6 +95,9 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     /// The collected content.
     T collectedContent;
 
+    private long currentPosition;
+    private boolean positionCollected;
+
     <I> CollectionMergeCursor(Trie.CollectionMergeResolver<T> resolver, Direction direction, Collection<I> inputs, IntFunction<C[]> cursorArrayConstructor, BiFunction<I, Direction, C> extractor)
     {
         this.resolver = resolver;
@@ -115,6 +118,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         }
 
         // The cursors are all currently positioned on the root and thus in valid heap order.
+        assert Arrays.stream(heap).allMatch(x -> equalCursor(head, x));
     }
 
     /// Interface for internal operations that can be applied to selected top elements of the heap.
@@ -241,14 +245,22 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     private long maybeSwapHead(long headPosition)
     {
         long heap0Position = heap[0].encodedPosition();
-        if (Cursor.compare(headPosition, heap0Position) <= 0)
+        long cmp = Cursor.compare(headPosition, heap0Position);
+        if (cmp < 0)
+        {
+            currentPosition = headPosition;
+            positionCollected = true;
             return headPosition;   // head is still smallest
+        }
 
-        // otherwise we need to swap heap and heap[0]
-        C newHeap0 = head;
-        head = heap[0];
-        heapifyDown(newHeap0, 0);
-        return heap0Position;
+        if (cmp > 0)
+        {
+            // otherwise we need to swap heap and heap[0]
+            C newHeap0 = head;
+            head = heap[0];
+            heapifyDown(newHeap0, 0);
+        }
+        return encodedPosition();
     }
 
     boolean branchHasMultipleSources()
@@ -265,6 +277,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     public long advance()
     {
         contentCollected = false;
+        positionCollected = false;
         return doAdvance();
     }
 
@@ -278,6 +291,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     public long advanceMultiple(TransitionsReceiver receiver)
     {
         contentCollected = false;
+        positionCollected = false;
         // If the current position is present in just one cursor, we can safely descend multiple levels within
         // its branch as no one of the other tries has content for it.
         if (branchHasMultipleSources())
@@ -317,6 +331,7 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
         }
 
         contentCollected = false;
+        positionCollected = false;
         applyToSelectedElementsInHeap(new SkipTo(), 0);
         return maybeSwapHead(head.skipTo(encodedSkipPosition));
     }
@@ -324,7 +339,25 @@ abstract class CollectionMergeCursor<T, C extends Cursor<T>> implements Cursor<T
     @Override
     public long encodedPosition()
     {
-        return head.encodedPosition();
+        if (!positionCollected)
+        {
+            long pos = head.encodedPosition();
+            if (Cursor.isExhausted(pos) || !branchHasMultipleSources())
+                currentPosition = pos;
+            else
+            {
+                // Returns head's position with flags unioned from all cursors at the same position,
+                // since multiple sources may each contribute flags (e.g. MAY_HAVE_CONTENT_BIT) that
+                // the head alone would not reflect.
+                currentPosition = pos;
+                applyToSelectedElementsInHeap((self, cursor, index) -> {
+                    currentPosition |= cursor.encodedPosition();
+                }, 0);
+                currentPosition = Cursor.unionFlags(pos, currentPosition, Cursor.FLAGS_MASK);
+            }
+            positionCollected = true;
+        }
+        return currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/Cursor.java
+++ b/src/java/org/apache/cassandra/db/tries/Cursor.java
@@ -143,6 +143,7 @@ interface Cursor<T>
     /// Flag indicating whether this position may have content.
     long MAY_HAVE_CONTENT_BIT = 1L;
 
+    /// Mask of the transition bits including the direction. We apply xor with this value to form a position in the
     /// reverse direction.
     long TRANSITION_MASK = 0x8FFL << TRANSITION_SHIFT;
 
@@ -209,9 +210,20 @@ interface Cursor<T>
 
     /// Returns a new position with flags from pos2 combined using union operation.
     /// Union: (pos1 | pos2) & flags | (pos1 & ~flags)
+    /// This preserves the structural bits (depth, transition) from pos1 and combines the specified flags from both positions.
     static long unionFlags(long pos1, long pos2, long flags)
     {
         return (pos1 | pos2) & flags | (pos1 & ~flags);
+    }
+
+    /// Returns a new position with flags from pos2 combined using union operation.
+    /// This version is optimized for cases where the position bits (depth and incoming transition) are known to match.
+    /// The assertion validates this invariant in debug builds.
+    static long unionFlagsMatchingPositions(long pos1, long pos2)
+    {
+        assert compare(pos1, pos2) == 0 : 
+            String.format("Position mismatch in unionFlagsMatchingPositions: compare(%016x, %016x) = %d", pos1, pos2, compare(pos1, pos2));
+        return pos1 | pos2;
     }
 
     /// Returns a new position with flags from pos2 combined using intersection operation.
@@ -292,7 +304,7 @@ interface Cursor<T>
                              depth(encodedPosition),
                              incomingTransition(encodedPosition),
                              isOnReturnPath(encodedPosition) ? "↑" : " ",
-                             (encodedPosition & MAY_HAVE_CONTENT_BIT) != 0 ? "*" : " ",
+                             (encodedPosition & MAY_HAVE_CONTENT_BIT) != 0 ? "C" : " ",
                              direction(encodedPosition));
     }
 

--- a/src/java/org/apache/cassandra/db/tries/Cursor.java
+++ b/src/java/org/apache/cassandra/db/tries/Cursor.java
@@ -137,7 +137,12 @@ interface Cursor<T>
     /// Used for sets and ranges to correctly define the range states for branch-inclusive ranges.
     long ON_RETURN_PATH_BIT = 1L << 19;
 
-    /// Mask of the transition bits including the direction. We apply xor with this value to form a position in the
+    /// Mask for the bits used for flags that should not affect position comparison.
+    long FLAGS_MASK = 0xFFFFL;
+
+    /// Flag indicating whether this position may have content.
+    long MAY_HAVE_CONTENT_BIT = 1L;
+
     /// reverse direction.
     long TRANSITION_MASK = 0x8FFL << TRANSITION_SHIFT;
 
@@ -198,8 +203,24 @@ interface Cursor<T>
     static long compare(long encoded1, long encoded2)
     {
         // This can support depth of 2^31 - 1 without overflowing.
-        return encoded1 - encoded2;
+        return (encoded1 & ~FLAGS_MASK) - (encoded2 & ~FLAGS_MASK);
     }
+
+
+    /// Returns a new position with flags from pos2 combined using union operation.
+    /// Union: (pos1 | pos2) & flags | (pos1 & ~flags)
+    static long unionFlags(long pos1, long pos2, long flags)
+    {
+        return (pos1 | pos2) & flags | (pos1 & ~flags);
+    }
+
+    /// Returns a new position with flags from pos2 combined using intersection operation.
+    /// Intersection: pos1 & pos2 & flags | (pos1 & ~flags)
+    static long intersectionFlags(long pos1, long pos2, long flags)
+    {
+        return pos1 & pos2 & flags | (pos1 & ~flags);
+    }
+
 
     static long rootPosition(Direction direction)
     {
@@ -225,7 +246,7 @@ interface Cursor<T>
 
     static boolean isRootPosition(long encodedPosition)
     {
-        return encodedPosition == ROOT_POSITION_FORWARD || encodedPosition == ROOT_POSITION_REVERSE;
+        return compare(encodedPosition, ROOT_POSITION_FORWARD) == 0 || compare(encodedPosition, ROOT_POSITION_REVERSE) == 0;
     }
 
     static long encode(int depth, int transition, Direction direction)
@@ -252,7 +273,7 @@ interface Cursor<T>
     /// returned encoded position is a valid `skipTo` position for the current state.
     static long positionForSkippingBranch(long encodedBranchPosition)
     {
-        return encodedBranchPosition + (1L << TRANSITION_SHIFT);
+        return (encodedBranchPosition & ~FLAGS_MASK) + (1L << TRANSITION_SHIFT);
     }
 
     /// Returns true if the given `currPosition` as returned by `advance`, `advanceMultiple` or `skipTo` is the result
@@ -267,10 +288,11 @@ interface Cursor<T>
 
     static String toString(long encodedPosition)
     {
-        return String.format("depth %d incomingTransition %02x%s %s",
+        return String.format("depth %d incomingTransition %02x%s%s %s",
                              depth(encodedPosition),
                              incomingTransition(encodedPosition),
                              isOnReturnPath(encodedPosition) ? "↑" : " ",
+                             (encodedPosition & MAY_HAVE_CONTENT_BIT) != 0 ? "*" : " ",
                              direction(encodedPosition));
     }
 
@@ -361,9 +383,12 @@ interface Cursor<T>
                 if (isOnReturnPath(currPosition))
                     receiver.onReturnPath();
             }
-            T content = content();
-            if (content != null)
-                return content;
+            if ((currPosition & MAY_HAVE_CONTENT_BIT) != 0)
+            {
+                T content = content();
+                if (content != null)
+                    return content;
+            }
             prevPosition = currPosition;
         }
     }
@@ -406,7 +431,8 @@ interface Cursor<T>
         while (next != ByteSource.END_OF_STREAM)
         {
             long nextPosition = positionForDescentWithByte(position, next);
-            if (compare(skipTo(nextPosition), nextPosition) != 0)
+            long arrived = skipTo(nextPosition);
+            if (compare(arrived, nextPosition) != 0)
                 return false;
             next = bytes.next();
             position = nextPosition;
@@ -463,7 +489,8 @@ interface Cursor<T>
     default <R> R process(Cursor.Walker<? super T, R> walker)
     {
         assertFresh();
-        T content = content();   // handle content on the root node
+        long currentPosition = encodedPosition();
+        T content = (currentPosition & MAY_HAVE_CONTENT_BIT) != 0 ? content() : null;
         if (content == null)
             content = advanceToContent(walker);
 
@@ -487,7 +514,8 @@ interface Cursor<T>
     default <R> R processSkippingBranches(Cursor.Walker<? super T, R> walker)
     {
         assertFresh();
-        T content = content();   // handle content on the root node
+        long currentPosition = encodedPosition();
+        T content = (currentPosition & MAY_HAVE_CONTENT_BIT) != 0 ? content() : null;
         if (content != null)
         {
             walker.content(content);
@@ -504,7 +532,7 @@ interface Cursor<T>
                 break;
             walker.resetPathLength(depth(current) - 1);
             walker.addPathByte(incomingTransition(current));
-            content = content();
+            content = (current & MAY_HAVE_CONTENT_BIT) != 0 ? content() : null;
             if (content == null)
                 content = advanceToContent(walker);
         }
@@ -541,7 +569,7 @@ interface Cursor<T>
         @Override
         public Cursor<T> tailCursor(Direction direction)
         {
-            assert position == Cursor.rootPosition(direction) : "tailTrie called on exhausted cursor";
+            assert compare(position, Cursor.rootPosition(direction)) == 0 : "tailTrie called on exhausted cursor";
             return new Empty<>(direction, byteComparableVersion);
         }
 

--- a/src/java/org/apache/cassandra/db/tries/Cursor.java
+++ b/src/java/org/apache/cassandra/db/tries/Cursor.java
@@ -204,7 +204,8 @@ interface Cursor<T>
     static long compare(long encoded1, long encoded2)
     {
         // This can support depth of 2^31 - 1 without overflowing.
-        return (encoded1 & ~FLAGS_MASK) - (encoded2 & ~FLAGS_MASK);
+        // Normalise the flag bits to the same value in both operands before subtracting.
+        return (encoded1 | FLAGS_MASK) - (encoded2 | FLAGS_MASK);
     }
 
 

--- a/src/java/org/apache/cassandra/db/tries/DeletionAwareCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/DeletionAwareCursor.java
@@ -87,14 +87,20 @@ public interface DeletionAwareCursor<T, D extends RangeState<D>> extends Cursor<
 
         while (true)
         {
-            T content = content();   // handle content on the root node
-            if (content != null)
-                walker.content(content);
+            // Always check for deletion branches as they are independent of content
             RangeCursor<D> deletionBranch = deletionBranchCursor(direction());
             if (deletionBranch != null && walker.enterDeletionsBranch())
             {
                 processDeletionBranch(walker, deletionBranch);
                 walker.exitDeletionsBranch();
+            }
+            
+            // MAY_HAVE_CONTENT_BIT optimization: only call content() if flag indicates potential content
+            if ((currentPosition & MAY_HAVE_CONTENT_BIT) != 0)
+            {
+                T content = content();
+                if (content != null)
+                    walker.content(content);
             }
 
             long prevPosition = currentPosition;
@@ -113,7 +119,7 @@ public interface DeletionAwareCursor<T, D extends RangeState<D>> extends Cursor<
     private static <D> void processDeletionBranch(DeletionAwareWalker<?, ? super D, ?> walker, Cursor<D> cursor)
     {
         cursor.assertFresh();
-        D content = cursor.content();   // handle content on the root node
+        D content = (cursor.encodedPosition() & MAY_HAVE_CONTENT_BIT) != 0 ? cursor.content() : null;
         if (content == null)
             content = cursor.advanceToContent(walker);
 

--- a/src/java/org/apache/cassandra/db/tries/DeletionAwareMergeSource.java
+++ b/src/java/org/apache/cassandra/db/tries/DeletionAwareMergeSource.java
@@ -131,7 +131,7 @@ class DeletionAwareMergeSource<T, D extends RangeState<D>, E extends RangeState<
         if (Cursor.isExhausted(deletionsPositionUncorrected))
             return leaveDeletionsBranch(dataPosition);
         else
-            return setAtDeletionsAndReturnPosition(deletionsPositionUncorrected == deletionsSkipPosition,
+            return setAtDeletionsAndReturnPosition(Cursor.compare(deletionsPositionUncorrected, deletionsSkipPosition) == 0,
                                                    dataPosition);
     }
 

--- a/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
@@ -46,8 +46,9 @@ class DepthAdjustedCursor<T, C extends Cursor<T>> implements Cursor<T>
         else if (Cursor.isExhausted(position))
             return position;
         else
-            // Combine structural bits of matchingPositionAtRoot with return path bit and flags from position.
-            return Cursor.unionFlags(matchingPositionAtRoot, position, Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK);
+            // Combine structural bits of matchingPositionAtRoot (without its flags) with return path bit and flags from position.
+            // Clear any flags from matchingPositionAtRoot to ensure only source position flags are preserved.
+            return Cursor.unionFlags(matchingPositionAtRoot & ~Cursor.FLAGS_MASK, position, Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK);
     }
 
     long fromAdjustedDepth(long position)

--- a/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
@@ -24,8 +24,8 @@ import org.apache.cassandra.utils.bytecomparable.ByteSource;
 class DepthAdjustedCursor<T, C extends Cursor<T>> implements Cursor<T>
 {
     final C source;
-    private long depthAdjustment;
-    private long matchingPositionAtRoot;
+    protected long depthAdjustment;
+    protected long matchingPositionAtRoot;
 
     DepthAdjustedCursor(C source, long matchingPositionAtRoot)
     {

--- a/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
@@ -46,7 +46,8 @@ class DepthAdjustedCursor<T, C extends Cursor<T>> implements Cursor<T>
         else if (Cursor.isExhausted(position))
             return position;
         else
-            return matchingPositionAtRoot | (position & Cursor.ON_RETURN_PATH_BIT);
+            // Combine structural bits of matchingPositionAtRoot with return path bit and flags from position.
+            return Cursor.unionFlags(matchingPositionAtRoot, position, Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK);
     }
 
     long fromAdjustedDepth(long position)
@@ -57,7 +58,7 @@ class DepthAdjustedCursor<T, C extends Cursor<T>> implements Cursor<T>
             return adjusted;
 
         // The only non-exhausted position that can be requested with this depth is the return path stop for the root.
-        if (position == (matchingPositionAtRoot | Cursor.ON_RETURN_PATH_BIT))
+        if (Cursor.compare(position, matchingPositionAtRoot | Cursor.ON_RETURN_PATH_BIT) == 0)
             return Cursor.rootReturnPosition(adjusted);
         else
             return Cursor.exhaustedPosition(adjusted);

--- a/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/DepthAdjustedCursor.java
@@ -61,7 +61,6 @@ class DepthAdjustedCursor<T, C extends Cursor<T>> implements Cursor<T>
             return Cursor.rootReturnPosition(adjusted);
         else
             return Cursor.exhaustedPosition(adjusted);
-
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/FlexibleMergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/FlexibleMergeCursor.java
@@ -61,7 +61,7 @@ abstract class FlexibleMergeCursor<C extends Cursor<?>, D extends Cursor<?>, T> 
         state = c2 != null ? State.AT_BOTH : State.C1_ONLY;
         currentPosition = c1.encodedPosition();
         if (c2 != null)
-            currentPosition = Cursor.unionFlags(currentPosition, c2.encodedPosition(), Cursor.FLAGS_MASK);
+            currentPosition = Cursor.unionFlagsMatchingPositions(currentPosition, c2.encodedPosition());
         // We can't call postAdvance here because the class may not be completely initialized.
         // The concrete class should do that instead
     }
@@ -178,7 +178,7 @@ abstract class FlexibleMergeCursor<C extends Cursor<?>, D extends Cursor<?>, T> 
         }
         // c1pos == c2pos
         state = State.AT_BOTH;
-        currentPosition = Cursor.unionFlags(c1pos, c2pos, Cursor.FLAGS_MASK);
+        currentPosition = Cursor.unionFlagsMatchingPositions(c1pos, c2pos);
         return postAdvance(currentPosition);
     }
 

--- a/src/java/org/apache/cassandra/db/tries/FlexibleMergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/FlexibleMergeCursor.java
@@ -53,12 +53,15 @@ abstract class FlexibleMergeCursor<C extends Cursor<?>, D extends Cursor<?>, T> 
     FlexibleMergeCursor(C c1, D c2)
     {
         c1.assertFresh();
-        c2.assertFresh();
+        if (c2 != null)
+            c2.assertFresh();
         this.c1 = c1;
         this.c2 = c2;
         this.c2depthCorrection = 0;
         state = c2 != null ? State.AT_BOTH : State.C1_ONLY;
         currentPosition = c1.encodedPosition();
+        if (c2 != null)
+            currentPosition = Cursor.unionFlags(currentPosition, c2.encodedPosition(), Cursor.FLAGS_MASK);
         // We can't call postAdvance here because the class may not be completely initialized.
         // The concrete class should do that instead
     }
@@ -70,6 +73,7 @@ abstract class FlexibleMergeCursor<C extends Cursor<?>, D extends Cursor<?>, T> 
         this.c2 = c2;
         this.c2depthCorrection = Cursor.depthCorrectionValue(currentPosition);
         this.state = State.AT_BOTH;
+        currentPosition = Cursor.unionFlags(currentPosition, c2.encodedPosition(), Cursor.FLAGS_MASK);
     }
 
     abstract long postAdvance(long depth);
@@ -174,7 +178,8 @@ abstract class FlexibleMergeCursor<C extends Cursor<?>, D extends Cursor<?>, T> 
         }
         // c1pos == c2pos
         state = State.AT_BOTH;
-        return postAdvance(currentPosition = c1pos);
+        currentPosition = Cursor.unionFlags(c1pos, c2pos, Cursor.FLAGS_MASK);
+        return postAdvance(currentPosition);
     }
 
     private long leaveC2(long c1pos)

--- a/src/java/org/apache/cassandra/db/tries/InMemoryBaseTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryBaseTrie.java
@@ -1421,14 +1421,15 @@ public abstract class InMemoryBaseTrie<T> extends InMemoryReadTrie<T>
         Mutator<T, U, C, A> apply() throws TrieSpaceExhaustedException
         {
             int depth = state.currentDepth;
+            long position = mutationCursor.encodedPosition();
             while (true)
             {
                 if (depth < forcedCopyDepth)
                     forcedCopyDepth = needsForcedCopy.test(this) ? depth : Integer.MAX_VALUE;
 
-                applyContent(mutationCursor.content());
+                applyContent((position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null);
 
-                long position = mutationCursor.advance();
+                position = mutationCursor.advance();
                 assert !Cursor.isOnReturnPath(position) : "Return path in forward direction can only be used in range tries.";
                 depth = Cursor.depth(position);
                 if (!state.advanceTo(depth, Cursor.incomingTransition(position), forcedCopyDepth))
@@ -1474,7 +1475,7 @@ public abstract class InMemoryBaseTrie<T> extends InMemoryReadTrie<T>
         @Override
         public U content()
         {
-            return mutationCursor.content();
+            return (mutationCursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null;
         }
 
         /// Return the depth of the currently processed node.

--- a/src/java/org/apache/cassandra/db/tries/InMemoryDeletionAwareTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryDeletionAwareTrie.java
@@ -284,6 +284,7 @@ extends InMemoryBaseTrie<T> implements DeletionAwareTrie<T, D>
         Mutator<V, E> apply() throws TrieSpaceExhaustedException
         {
             int depth = state.currentDepth;
+            long position = mutationCursor.encodedPosition();
             while (true)
             {
                 if (depth < forcedCopyDepth)
@@ -291,11 +292,10 @@ extends InMemoryBaseTrie<T> implements DeletionAwareTrie<T, D>
 
                 // Content must be applied before descending into the branch to make sure we call the transformers
                 // in the right order.
-                applyContent(mutationCursor.content());
+                applyContent((position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null);
 
                 int existingAlternateBranch = state.alternateBranch();
                 RangeCursor<E> incomingAlternateBranch = mutationCursor.deletionBranchCursor(Direction.FORWARD);
-                long position;
                 if (incomingAlternateBranch != null || existingAlternateBranch != NONE)
                 {
                     int updatedAlternateBranch = existingAlternateBranch;
@@ -372,7 +372,7 @@ extends InMemoryBaseTrie<T> implements DeletionAwareTrie<T, D>
                 if (depth < forcedCopyDepth)
                     forcedCopyDepth = needsForcedCopy.test(this) ? depth : Integer.MAX_VALUE;
 
-                applyContent(mutationCursor.content());
+                applyContent((position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null);
                 position = mutationCursor.advance();
                 depth = Cursor.depth(position);
             }

--- a/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
@@ -277,6 +277,8 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
             if (rootAscentContent != null)
                 addBacktrack(NONE, 0, -1);
             setNodeState(currentPosition, rootDescentContent, currentFullNode, currentNode);
+            if (rootDescentContent != null)
+                currentPosition |= MAY_HAVE_CONTENT_BIT;
             updateActiveAndReturn(currentPosition);
         }
 

--- a/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
@@ -137,6 +137,8 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
         {
             if (!Cursor.isExhausted(position))
             {
+                currentPosition = position | MAY_HAVE_CONTENT_BIT;
+
                 // Always check if we are seeing new content; if we do, that's an easy state update.
                 S content = content();
                 if (content != null)
@@ -271,11 +273,11 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
         InMemoryRangeBranchCursor(InMemoryReadTrie<S> trie, Direction direction, int root, S rootDescentContent, S rootAscentContent)
         {
             super(trie, direction, root);
-            content = rootDescentContent;
             this.rootAscentContent = rootAscentContent;
             if (rootAscentContent != null)
                 addBacktrack(NONE, 0, -1);
-            updateActiveAndReturn(encodedPosition());
+            setNodeState(currentPosition, rootDescentContent, currentFullNode, currentNode);
+            updateActiveAndReturn(currentPosition);
         }
 
         @Override
@@ -299,7 +301,7 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
 
         long presentAscentPathContent()
         {
-            return setNodeState(Cursor.encode(++depth, 0, direction) | ON_RETURN_PATH_BIT,
+            return setNodeState(Cursor.unionFlags(Cursor.encode(++depth, 0, direction), MAY_HAVE_CONTENT_BIT, MAY_HAVE_CONTENT_BIT) | ON_RETURN_PATH_BIT,
                                 rootAscentContent,
                                 NONE,
                                 NONE);

--- a/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
@@ -137,10 +137,10 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
         {
             if (!Cursor.isExhausted(position))
             {
-                currentPosition = position | MAY_HAVE_CONTENT_BIT;
+                currentPosition = position;
 
                 // Always check if we are seeing new content; if we do, that's an easy state update.
-                S content = content();
+                S content = (position & MAY_HAVE_CONTENT_BIT) != 0 ? content() : null;
                 if (content != null)
                 {
                     activeRange = content;
@@ -301,7 +301,7 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
 
         long presentAscentPathContent()
         {
-            return setNodeState(Cursor.unionFlags(Cursor.encode(++depth, 0, direction), MAY_HAVE_CONTENT_BIT, MAY_HAVE_CONTENT_BIT) | ON_RETURN_PATH_BIT,
+            return setNodeState(Cursor.encode(++depth, 0, direction) | MAY_HAVE_CONTENT_BIT | ON_RETURN_PATH_BIT,
                                 rootAscentContent,
                                 NONE,
                                 NONE);

--- a/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryRangeTrie.java
@@ -140,7 +140,7 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
                 currentPosition = position;
 
                 // Always check if we are seeing new content; if we do, that's an easy state update.
-                S content = (position & MAY_HAVE_CONTENT_BIT) != 0 ? content() : null;
+                S content = this.content;
                 if (content != null)
                 {
                     activeRange = content;
@@ -651,7 +651,7 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
                 if (depth < forcedCopyDepth)
                     forcedCopyDepth = needsForcedCopy.test(this) ? depth : Integer.MAX_VALUE;
 
-                U content = mutationCursor.content();
+                U content = (position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null;
                 if (content != null)
                 {
                     S existingCoveringState = getExistingCoveringState(Cursor.isOnReturnPath(position));
@@ -704,7 +704,7 @@ public class InMemoryRangeTrie<S extends RangeState<S>> extends InMemoryBaseTrie
                     case AT_LIMIT:
                     {
                         // We are following the mutation cursor. Check it for content to apply, and then advance it.
-                        U mutationContent = mutationCursor.content();
+                        U mutationContent = (position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null;
 
                         int existingContentId = limitOnReturnPath ? state.getAscentPathContentId() : state.descentPathContentId();
                         S existingContent = InMemoryReadTrie.isNull(existingContentId) ? null : state.trie.getContent(existingContentId);

--- a/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
@@ -1237,16 +1237,22 @@ public abstract class InMemoryReadTrie<T>
                         // There's no reason to delay going to the position of the content.
                         currentPosition |= ON_RETURN_PATH_BIT;
                         content = trie.getContent(node);
+                        currentPosition |= MAY_HAVE_CONTENT_BIT;
                     }
                 }
                 else
+                {
                     content = trie.getContent(node);
+                    currentPosition |= MAY_HAVE_CONTENT_BIT;
+                }
 
                 currentNode = NONE;
             }
             else if (offset(node) == PREFIX_OFFSET)
             {
                 content = processPrefix(node, depth, transition);
+                if (content != null)
+                    currentPosition |= MAY_HAVE_CONTENT_BIT;
                 currentNode = trie.getChildOfPrefixNode(node);
             }
             else
@@ -1254,9 +1260,6 @@ public abstract class InMemoryReadTrie<T>
                 content = null;
                 currentNode = node;
             }
-
-            if (content != null || isLeaf(node))
-                currentPosition |= MAY_HAVE_CONTENT_BIT;
         }
 
         /// Get the content from a prefix node and/or put a backtracking entry for return path data.
@@ -1312,7 +1315,7 @@ public abstract class InMemoryReadTrie<T>
         long setNodeState(long nextPosition, T nodeContent, int fullNode, int node)
         {
             currentPosition = nextPosition;
-            if (nodeContent != null || isLeaf(fullNode))
+            if (nodeContent != null)
                 currentPosition |= MAY_HAVE_CONTENT_BIT;
             content = nodeContent;
             currentFullNode = fullNode;

--- a/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
@@ -1432,7 +1432,7 @@ public abstract class InMemoryReadTrie<T>
                 }
             }
 
-            T content = source.content();
+            T content = (source.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? source.content() : null;
             if (content != null)
             {
                 if (type != null)

--- a/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
@@ -686,7 +686,7 @@ public abstract class InMemoryReadTrie<T>
         final InMemoryReadTrie<T> trie;
         int currentNode;
         int currentFullNode;
-        private long currentPosition;
+        protected long currentPosition;
         protected int depth;
         protected T content;
         final Direction direction;
@@ -1254,6 +1254,9 @@ public abstract class InMemoryReadTrie<T>
                 content = null;
                 currentNode = node;
             }
+
+            if (content != null || isLeaf(node))
+                currentPosition |= MAY_HAVE_CONTENT_BIT;
         }
 
         /// Get the content from a prefix node and/or put a backtracking entry for return path data.
@@ -1294,23 +1297,27 @@ public abstract class InMemoryReadTrie<T>
         long descendInto(int child, int transition)
         {
             ++depth;
-            currentPosition = Cursor.encode(depth, transition, direction);
+            long pos = Cursor.encode(depth, transition, direction);
+            currentPosition = pos;
             setCurrentNodeAndApplyPrefixes(child, depth, transition, false);
             return currentPosition;
         }
 
         long descendIntoChain(int child, int transition)
         {
-            return setNodeState(Cursor.encode(++depth, transition, direction), null, child, child);
+            long pos = Cursor.encode(++depth, transition, direction);
+            return setNodeState(pos, null, child, child);
         }
 
         long setNodeState(long nextPosition, T nodeContent, int fullNode, int node)
         {
             currentPosition = nextPosition;
+            if (nodeContent != null || isLeaf(fullNode))
+                currentPosition |= MAY_HAVE_CONTENT_BIT;
             content = nodeContent;
             currentFullNode = fullNode;
             currentNode = node;
-            return nextPosition;
+            return currentPosition;
         }
     }
 

--- a/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryReadTrie.java
@@ -1315,8 +1315,6 @@ public abstract class InMemoryReadTrie<T>
         long setNodeState(long nextPosition, T nodeContent, int fullNode, int node)
         {
             currentPosition = nextPosition;
-            if (nodeContent != null)
-                currentPosition |= MAY_HAVE_CONTENT_BIT;
             content = nodeContent;
             currentFullNode = fullNode;
             currentNode = node;

--- a/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
+++ b/src/java/org/apache/cassandra/db/tries/InMemoryTrie.java
@@ -306,7 +306,7 @@ public class InMemoryTrie<T> extends InMemoryBaseTrie<T> implements Trie<T>
                 if (depth < forcedCopyDepth)
                     forcedCopyDepth = needsForcedCopy.test(this) ? depth : Integer.MAX_VALUE;
 
-                S content = mutationCursor.content();
+                S content = (position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null;
                 if (content != null)
                     applyDeletionRange(position);
 
@@ -341,7 +341,7 @@ public class InMemoryTrie<T> extends InMemoryBaseTrie<T> implements Trie<T>
                     if (state.currentDepth < forcedCopyDepth)
                         forcedCopyDepth = needsForcedCopy.test(this) ? state.currentDepth : Integer.MAX_VALUE;
 
-                    S mutationContent = mutationCursor.content();
+                    S mutationContent = (position & Cursor.MAY_HAVE_CONTENT_BIT) != 0 ? mutationCursor.content() : null;
 
                     if (mutationContent != null)
                     {

--- a/src/java/org/apache/cassandra/db/tries/IntersectionCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/IntersectionCursor.java
@@ -203,9 +203,31 @@ abstract class IntersectionCursor<T, C extends Cursor<T>> implements Cursor<T>
         }
 
         @Override
+        public long advance()
+        {
+            return adjustPosition(super.advance());
+        }
+
+        @Override
+        public long advanceMultiple(TransitionsReceiver receiver)
+        {
+            return adjustPosition(super.advanceMultiple(receiver));
+        }
+
+        @Override
+        public long skipTo(long encodedSkipPosition)
+        {
+            return adjustPosition(super.skipTo(encodedSkipPosition));
+        }
+
+        @Override
         public long encodedPosition()
         {
-            long pos = super.encodedPosition();
+            return adjustPosition(super.encodedPosition());
+        }
+
+        private long adjustPosition(long pos)
+        {
             if (state == State.MATCHING && !set.state().applicableAfter)
                 pos &= ~Cursor.MAY_HAVE_CONTENT_BIT;
             return pos;

--- a/src/java/org/apache/cassandra/db/tries/IntersectionCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/IntersectionCursor.java
@@ -201,6 +201,15 @@ abstract class IntersectionCursor<T, C extends Cursor<T>> implements Cursor<T>
                     throw new AssertionError();
             }
         }
+
+        @Override
+        public long encodedPosition()
+        {
+            long pos = super.encodedPosition();
+            if (state == State.MATCHING && !set.state().applicableAfter)
+                pos &= ~Cursor.MAY_HAVE_CONTENT_BIT;
+            return pos;
+        }
     }
 
     /// Intersection cursor for [Trie].

--- a/src/java/org/apache/cassandra/db/tries/MergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/MergeCursor.java
@@ -37,6 +37,7 @@ abstract class MergeCursor<T, C extends Cursor<T>, U, D extends Cursor<U>, R> im
 
     boolean atC1;
     boolean atC2;
+    long currentPosition;
 
     MergeCursor(C c1, D c2)
     {
@@ -45,6 +46,7 @@ abstract class MergeCursor<T, C extends Cursor<T>, U, D extends Cursor<U>, R> im
         this.c1 = c1;
         this.c2 = c2;
         atC1 = atC2 = true;
+        currentPosition = Cursor.unionFlags(c1.encodedPosition(), c2.encodedPosition(), Cursor.FLAGS_MASK);
     }
 
     @Override
@@ -83,13 +85,16 @@ abstract class MergeCursor<T, C extends Cursor<T>, U, D extends Cursor<U>, R> im
         long cmp = Cursor.compare(c1pos, c2pos);
         atC1 = cmp <= 0;
         atC2 = cmp >= 0;
-        return atC1 ? c1pos : c2pos;
+        if (atC1 && atC2)
+            return currentPosition = Cursor.unionFlags(c1pos, c2pos, Cursor.FLAGS_MASK);
+        else
+            return currentPosition = atC1 ? c1pos : c2pos;
     }
 
     @Override
     public long encodedPosition()
     {
-        return atC1 ? c1.encodedPosition() : c2.encodedPosition();
+        return currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/MergeCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/MergeCursor.java
@@ -46,7 +46,7 @@ abstract class MergeCursor<T, C extends Cursor<T>, U, D extends Cursor<U>, R> im
         this.c1 = c1;
         this.c2 = c2;
         atC1 = atC2 = true;
-        currentPosition = Cursor.unionFlags(c1.encodedPosition(), c2.encodedPosition(), Cursor.FLAGS_MASK);
+        currentPosition = Cursor.unionFlagsMatchingPositions(c1.encodedPosition(), c2.encodedPosition());
     }
 
     @Override
@@ -86,7 +86,7 @@ abstract class MergeCursor<T, C extends Cursor<T>, U, D extends Cursor<U>, R> im
         atC1 = cmp <= 0;
         atC2 = cmp >= 0;
         if (atC1 && atC2)
-            return currentPosition = Cursor.unionFlags(c1pos, c2pos, Cursor.FLAGS_MASK);
+        return currentPosition = Cursor.unionFlagsMatchingPositions(c1pos, c2pos);
         else
             return currentPosition = atC1 ? c1pos : c2pos;
     }

--- a/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
@@ -267,6 +267,15 @@ abstract class PrefixedCursor<T, C extends Cursor<T>> extends DepthAdjustedCurso
         }
 
         @Override
+        public long encodedPosition()
+        {
+            long pos = super.encodedPosition();
+            if ((Cursor.isRootPosition(pos) || Cursor.compare(pos, matchingPositionAtRoot) == 0) && deletionBranch != null)
+                return Cursor.unionFlags(pos, MAY_HAVE_CONTENT_BIT, MAY_HAVE_CONTENT_BIT);
+            return pos;
+        }
+
+        @Override
         public RangeCursor<D> deletionBranchCursor(Direction direction)
         {
             long pos = encodedPosition();

--- a/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
@@ -116,7 +116,10 @@ abstract class PrefixedCursor<T, C extends Cursor<T>> extends DepthAdjustedCurso
     private long setPositionAndCheckPrefixDone(long position)
     {
         if (nextPrefixByte == ByteSource.END_OF_STREAM)
+        {
             setAttachmentPoint(position);
+            position = toAdjustedDepth(source.encodedPosition());
+        }
 
         currentPosition = position;
         return position;
@@ -266,7 +269,8 @@ abstract class PrefixedCursor<T, C extends Cursor<T>> extends DepthAdjustedCurso
         @Override
         public RangeCursor<D> deletionBranchCursor(Direction direction)
         {
-            return Cursor.isRootPosition(encodedPosition()) && deletionBranch != null
+            long pos = encodedPosition();
+            return (Cursor.isRootPosition(pos) || Cursor.compare(pos, matchingPositionAtRoot) == 0) && deletionBranch != null
                    ? deletionBranch.tailCursor(direction)
                    : null;
         }
@@ -274,7 +278,8 @@ abstract class PrefixedCursor<T, C extends Cursor<T>> extends DepthAdjustedCurso
         @Override
         public DeletionAwareCursor<T, D> tailCursor(Direction direction)
         {
-            if (Cursor.isRootPosition(encodedPosition()))
+            long pos = encodedPosition();
+            if (Cursor.isRootPosition(pos) || Cursor.compare(pos, matchingPositionAtRoot) == 0)
                 return new DeletionAwareSeparately<>(this, direction);
             else
                 return super.tailCursor(direction);

--- a/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/PrefixedCursor.java
@@ -118,6 +118,8 @@ abstract class PrefixedCursor<T, C extends Cursor<T>> extends DepthAdjustedCurso
         if (nextPrefixByte == ByteSource.END_OF_STREAM)
         {
             setAttachmentPoint(position);
+            // Replace position with source's adjusted position to inherit its flags (e.g. MAY_HAVE_CONTENT_BIT).
+            // The prefix itself has no content; only the source does.
             position = toAdjustedDepth(source.encodedPosition());
         }
 

--- a/src/java/org/apache/cassandra/db/tries/RangeApplyCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/RangeApplyCursor.java
@@ -105,7 +105,7 @@ class RangeApplyCursor<T, S extends RangeState<S>> implements Cursor<T>
     private long skipRangeToDataPosition(long dataPosition)
     {
         long rangePosition = range.skipTo(dataPosition);
-        return setAtRangeAndReturnPosition(rangePosition == dataPosition,
+        return setAtRangeAndReturnPosition(Cursor.compare(rangePosition, dataPosition) == 0,
                                            dataPosition);
     }
 

--- a/src/java/org/apache/cassandra/db/tries/RangeIntersectionCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/RangeIntersectionCursor.java
@@ -40,7 +40,7 @@ class RangeIntersectionCursor<S extends RangeState<S>> implements RangeCursor<S>
         this.set = set;
         this.src = src;
         assert Cursor.compare(src.encodedPosition(), set.encodedPosition()) == 0;
-        matchingPosition(set.encodedPosition());
+        matchingPosition(src.encodedPosition());
     }
 
     @Override
@@ -168,7 +168,7 @@ class RangeIntersectionCursor<S extends RangeState<S>> implements RangeCursor<S>
         if (cmp < 0)
             return coveredAreaWithSourceAhead(setPosition);
         if (cmp == 0)
-            return matchingPosition(setPosition);
+            return matchingPosition(sourcePosition);
 
         // Advancing cursor moved beyond the ahead cursor. Check if roles have reversed.
         if (set.precedingIncluded())
@@ -184,7 +184,7 @@ class RangeIntersectionCursor<S extends RangeState<S>> implements RangeCursor<S>
             // Set is ahead of source, but outside the covered area. Skip source to set's position.
             long sourcePosition = src.skipTo(setPosition);
             if (Cursor.compare(sourcePosition, setPosition) == 0)
-                return matchingPosition(setPosition);
+                return matchingPosition(sourcePosition);
             if (src.precedingState() != null)
                 return coveredAreaWithSourceAhead(setPosition);
 
@@ -211,7 +211,7 @@ class RangeIntersectionCursor<S extends RangeState<S>> implements RangeCursor<S>
             // Set is ahead of source, but outside the covered area. Skip source to set's position.
             sourcePosition = src.skipTo(setPosition);
             if (Cursor.compare(setPosition, sourcePosition) == 0)
-                return matchingPosition(setPosition);
+                return matchingPosition(sourcePosition);
             if (src.precedingState() != null)
                 return coveredAreaWithSourceAhead(setPosition);
         }
@@ -245,9 +245,12 @@ class RangeIntersectionCursor<S extends RangeState<S>> implements RangeCursor<S>
     private long setState(State state, long position, S cursorState)
     {
         this.state = state;
-        this.currentPosition = position;
+        if (cursorState != null && cursorState.isBoundary())
+            this.currentPosition = position | MAY_HAVE_CONTENT_BIT;
+        else
+            this.currentPosition = position & ~MAY_HAVE_CONTENT_BIT;
         this.currentState = cursorState;
-        return position;
+        return this.currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/RangesCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/RangesCursor.java
@@ -166,8 +166,11 @@ class RangesCursor implements TrieSetCursor
         this.sources = sources;
         this.currentIdx = startIdx;
         this.endIdx = endIdxExclusive;
-        this.currentPosition = currentPosition;
         this.currentState = currentState;
+        if (currentState.isBoundary())
+            this.currentPosition = currentPosition | MAY_HAVE_CONTENT_BIT;
+        else
+            this.currentPosition = currentPosition & ~MAY_HAVE_CONTENT_BIT;
         this.endsAfterMask = endsAfterMask;
     }
 
@@ -238,8 +241,11 @@ class RangesCursor implements TrieSetCursor
             containedSelection |= direction.select(RangeState.APPLICABLE_AFTER, RangeState.APPLICABLE_BEFORE);
 
         currentState = RangeState.values()[containedSelection];
-        currentPosition = nextPosition;
-        return nextPosition;
+        if (currentState.isBoundary())
+            currentPosition = nextPosition | MAY_HAVE_CONTENT_BIT;
+        else
+            currentPosition = nextPosition & ~MAY_HAVE_CONTENT_BIT;
+        return currentPosition;
     }
 
     private long maybeOnReturnPath(long nextPosition, int index, Direction direction)

--- a/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
@@ -83,7 +83,7 @@ class SingletonCursor<T> implements Cursor<T>
         currentPosition = nextPosition;
         if (!Cursor.isExhausted(nextPosition))
             prepareNextPosition(currentPosition);
-        return currentPosition;
+        return encodedPosition();
     }
 
     @Override
@@ -106,7 +106,7 @@ class SingletonCursor<T> implements Cursor<T>
         }
         currentPosition = Cursor.positionForDescentWithByte(pos, current);
         nextPosition = Cursor.exhaustedPosition(currentPosition);
-        return currentPosition;
+        return encodedPosition();
     }
 
     @Override
@@ -132,7 +132,7 @@ class SingletonCursor<T> implements Cursor<T>
     @Override
     public long encodedPosition()
     {
-        return currentPosition;
+        return atEnd() ? currentPosition | MAY_HAVE_CONTENT_BIT : currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
@@ -83,7 +83,9 @@ class SingletonCursor<T> implements Cursor<T>
         currentPosition = nextPosition;
         if (!Cursor.isExhausted(nextPosition))
             prepareNextPosition(currentPosition);
-        return encodedPosition();
+        if (atEnd())
+            currentPosition |= MAY_HAVE_CONTENT_BIT;
+        return currentPosition;
     }
 
     @Override
@@ -106,7 +108,9 @@ class SingletonCursor<T> implements Cursor<T>
         }
         currentPosition = Cursor.positionForDescentWithByte(pos, current);
         nextPosition = Cursor.exhaustedPosition(currentPosition);
-        return encodedPosition();
+        // atEnd() is unconditionally true here; set the bit directly.
+        currentPosition |= MAY_HAVE_CONTENT_BIT;
+        return currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/SingletonCursor.java
@@ -83,9 +83,7 @@ class SingletonCursor<T> implements Cursor<T>
         currentPosition = nextPosition;
         if (!Cursor.isExhausted(nextPosition))
             prepareNextPosition(currentPosition);
-        if (atEnd())
-            currentPosition |= MAY_HAVE_CONTENT_BIT;
-        return currentPosition;
+        return encodedPosition();
     }
 
     @Override
@@ -136,7 +134,9 @@ class SingletonCursor<T> implements Cursor<T>
     @Override
     public long encodedPosition()
     {
-        return atEnd() ? currentPosition | MAY_HAVE_CONTENT_BIT : currentPosition;
+        return Cursor.isExhausted(nextPosition) && !Cursor.isExhausted(currentPosition)
+               ? currentPosition | MAY_HAVE_CONTENT_BIT
+               : currentPosition;
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/SingletonOrderedCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/SingletonOrderedCursor.java
@@ -92,7 +92,7 @@ class SingletonOrderedCursor<T> extends SingletonCursor<T>
         super.advanceMultiple(receiver);
         if (presentOnReturnPath)
             currentPosition |= ON_RETURN_PATH_BIT;
-        return currentPosition;
+        return encodedPosition();
     }
 
     @Override

--- a/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
@@ -223,11 +223,13 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             NONE, ROOT, ROOT_RETURN, EXHAUSTED
         }
         Overriding overriding;
+        long currentPosition;
 
         Negated(TrieSetCursor source)
         {
             this.source = source;
             overriding = Overriding.ROOT;
+            updateCurrentPosition();
         }
 
         @Override
@@ -239,24 +241,29 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
         @Override
         public long encodedPosition()
         {
-            long encodedPosition = source.encodedPosition();
+            return currentPosition;
+        }
+
+        private long updateCurrentPosition()
+        {
+            long pos = source.encodedPosition();
             switch (overriding)
             {
                 case ROOT_RETURN:
-                    return Cursor.rootReturnPosition(encodedPosition) | MAY_HAVE_CONTENT_BIT;
+                    return currentPosition = Cursor.rootReturnPosition(pos) | MAY_HAVE_CONTENT_BIT;
                 case EXHAUSTED:
-                    return Cursor.exhaustedPosition(encodedPosition);
+                    return currentPosition = Cursor.exhaustedPosition(pos);
                 case ROOT:
                     // In ROOT case, set flag if negated state is a boundary
-                    if (!Cursor.isExhausted(encodedPosition) && state().isBoundary())
-                        encodedPosition |= MAY_HAVE_CONTENT_BIT;
+                    if (!Cursor.isExhausted(pos) && state().isBoundary())
+                        pos |= MAY_HAVE_CONTENT_BIT;
                     else
-                        encodedPosition &= ~MAY_HAVE_CONTENT_BIT;
-                    return encodedPosition;
+                        pos &= ~MAY_HAVE_CONTENT_BIT;
+                    return currentPosition = pos;
                 case NONE:
                 default:
                     // In NONE case, negation doesn't change boundary status (boundary stays boundary)
-                    return encodedPosition;
+                    return currentPosition = pos;
             }
         }
 
@@ -269,16 +276,17 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
         @Override
         public RangeState state()
         {
-            Direction dir = direction();
             switch (overriding)
             {
                 case ROOT:
+                    Direction dir = direction();
                     if (!source.state().succeedingIncluded(dir))
                         return dir.select(RangeState.START, RangeState.END);
                     else
                         return RangeState.NOT_CONTAINED;
                 case ROOT_RETURN:
-                    return dir.select(RangeState.END, RangeState.START);
+                    Direction dirReturn = direction();
+                    return dirReturn.select(RangeState.END, RangeState.START);
                 case EXHAUSTED:
                     return RangeState.NOT_CONTAINED;
                 case NONE:
@@ -293,7 +301,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             if (depth > 0)
             {
                 overriding = Overriding.NONE;
-                return encodedPosition;
+                return updateCurrentPosition();
             }
             else if (depth == 0)
             {
@@ -301,7 +309,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
                 // we no longer have. Go directly to exhausted.
                 assert Cursor.isOnReturnPath(encodedPosition);
                 overriding = Overriding.EXHAUSTED;
-                return encodedPosition();
+                return updateCurrentPosition();
             }
             else // depth < 0
             {
@@ -309,7 +317,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
                 // path to close it.
                 assert Cursor.isExhausted(encodedPosition);
                 overriding = Overriding.ROOT_RETURN;
-                return encodedPosition();
+                return updateCurrentPosition();
             }
         }
 
@@ -320,9 +328,9 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             {
                 case ROOT_RETURN:
                     overriding = Overriding.EXHAUSTED;
-                    return encodedPosition();
+                    return updateCurrentPosition();
                 default:
-                    // checkOverride already calls encodedPosition() when needed
+                    // checkOverride already calls updateCurrentPosition()
                     return checkOverride(source.advance());
             }
         }
@@ -334,7 +342,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
                 overriding = Overriding.EXHAUSTED;
             else
                 checkOverride(source.skipTo(encodedSkipPosition));
-            return encodedPosition();
+            return updateCurrentPosition();
         }
 
         // Sets don't implement advanceMultiple as they are only meant to limit data tries.

--- a/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
@@ -255,10 +255,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
                     return currentPosition = Cursor.exhaustedPosition(pos);
                 case ROOT:
                     // In ROOT case, set flag if negated state is a boundary
-                    if (!Cursor.isExhausted(pos) && state().isBoundary())
-                        pos |= MAY_HAVE_CONTENT_BIT;
-                    else
-                        pos &= ~MAY_HAVE_CONTENT_BIT;
+                    pos ^= MAY_HAVE_CONTENT_BIT;
                     return currentPosition = pos;
                 case NONE:
                 default:

--- a/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
@@ -217,6 +217,7 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
     class Negated implements TrieSetCursor
     {
         final TrieSetCursor source;
+        final Direction direction;
 
         enum Overriding
         {
@@ -227,7 +228,14 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
         Negated(TrieSetCursor source)
         {
             this.source = source;
+            this.direction = source.direction();
             overriding = Overriding.ROOT;
+        }
+
+        @Override
+        public Direction direction()
+        {
+            return direction;
         }
 
         @Override
@@ -237,12 +245,19 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             switch (overriding)
             {
                 case ROOT_RETURN:
-                    return Cursor.rootReturnPosition(encodedPosition);
+                    return Cursor.rootReturnPosition(encodedPosition) | MAY_HAVE_CONTENT_BIT;
                 case EXHAUSTED:
                     return Cursor.exhaustedPosition(encodedPosition);
                 case ROOT:
                 case NONE:
                 default:
+                    if (!Cursor.isExhausted(encodedPosition))
+                    {
+                        if (state().isBoundary())
+                            encodedPosition |= MAY_HAVE_CONTENT_BIT;
+                        else
+                            encodedPosition &= ~MAY_HAVE_CONTENT_BIT;
+                    }
                     return encodedPosition;
             }
         }
@@ -306,22 +321,22 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             {
                 case ROOT_RETURN:
                     overriding = Overriding.EXHAUSTED;
-                    return encodedPosition();
+                    break;
                 default:
-                    return checkOverride(source.advance());
+                    checkOverride(source.advance());
+                    break;
             }
+            return encodedPosition();
         }
 
         @Override
         public long skipTo(long encodedSkipPosition)
         {
             if (Cursor.isExhausted(encodedSkipPosition) || overriding == Overriding.ROOT_RETURN)
-            {
                 overriding = Overriding.EXHAUSTED;
-                return encodedPosition();
-            }
             else
-                return checkOverride(source.skipTo(encodedSkipPosition));
+                checkOverride(source.skipTo(encodedSkipPosition));
+            return encodedPosition();
         }
 
         // Sets don't implement advanceMultiple as they are only meant to limit data tries.

--- a/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/TrieSetCursor.java
@@ -217,7 +217,6 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
     class Negated implements TrieSetCursor
     {
         final TrieSetCursor source;
-        final Direction direction;
 
         enum Overriding
         {
@@ -228,14 +227,13 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
         Negated(TrieSetCursor source)
         {
             this.source = source;
-            this.direction = source.direction();
             overriding = Overriding.ROOT;
         }
 
         @Override
         public Direction direction()
         {
-            return direction;
+            return source.direction();
         }
 
         @Override
@@ -249,15 +247,15 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
                 case EXHAUSTED:
                     return Cursor.exhaustedPosition(encodedPosition);
                 case ROOT:
+                    // In ROOT case, set flag if negated state is a boundary
+                    if (!Cursor.isExhausted(encodedPosition) && state().isBoundary())
+                        encodedPosition |= MAY_HAVE_CONTENT_BIT;
+                    else
+                        encodedPosition &= ~MAY_HAVE_CONTENT_BIT;
+                    return encodedPosition;
                 case NONE:
                 default:
-                    if (!Cursor.isExhausted(encodedPosition))
-                    {
-                        if (state().isBoundary())
-                            encodedPosition |= MAY_HAVE_CONTENT_BIT;
-                        else
-                            encodedPosition &= ~MAY_HAVE_CONTENT_BIT;
-                    }
+                    // In NONE case, negation doesn't change boundary status (boundary stays boundary)
                     return encodedPosition;
             }
         }
@@ -271,15 +269,16 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
         @Override
         public RangeState state()
         {
+            Direction dir = direction();
             switch (overriding)
             {
                 case ROOT:
-                    if (!source.state().succeedingIncluded(direction()))
-                        return direction().select(RangeState.START, RangeState.END);
+                    if (!source.state().succeedingIncluded(dir))
+                        return dir.select(RangeState.START, RangeState.END);
                     else
                         return RangeState.NOT_CONTAINED;
                 case ROOT_RETURN:
-                    return direction().select(RangeState.END, RangeState.START);
+                    return dir.select(RangeState.END, RangeState.START);
                 case EXHAUSTED:
                     return RangeState.NOT_CONTAINED;
                 case NONE:
@@ -321,12 +320,11 @@ interface TrieSetCursor extends RangeCursor<TrieSetCursor.RangeState>
             {
                 case ROOT_RETURN:
                     overriding = Overriding.EXHAUSTED;
-                    break;
+                    return encodedPosition();
                 default:
-                    checkOverride(source.advance());
-                    break;
+                    // checkOverride already calls encodedPosition() when needed
+                    return checkOverride(source.advance());
             }
-            return encodedPosition();
         }
 
         @Override

--- a/src/java/org/apache/cassandra/db/tries/VerificationCursor.java
+++ b/src/java/org/apache/cassandra/db/tries/VerificationCursor.java
@@ -73,29 +73,31 @@ interface VerificationCursor
         {
             this.direction = cursor.direction();
             this.source = cursor;
-            this.returnedPosition = Cursor.rootPosition(direction);
+            this.returnedPosition = source.encodedPosition();
             this.path = new byte[16];
-            long reportedPosition = source.encodedPosition();
-            assert Cursor.direction(reportedPosition) == direction :
+            assert Cursor.direction(returnedPosition) == direction :
                 String.format("Invalid direction bit %d in root position %s (%016x)\n%s",
-                              (reportedPosition >> DIRECTION_BIT) & 1,
-                              Cursor.toString(reportedPosition),
-                              reportedPosition,
-                              this);
-            assert Cursor.compare(reportedPosition, returnedPosition) == 0 :
-                String.format("Invalid initial position %s (must be %s)\n%s",
-                              Cursor.toString(reportedPosition),
+                              (returnedPosition >> DIRECTION_BIT) & 1,
                               Cursor.toString(returnedPosition),
+                              returnedPosition,
+                              this);
+            assert Cursor.compare(returnedPosition, Cursor.rootPosition(direction)) == 0 :
+                String.format("Invalid initial position %s (must be %s)\n%s",
+                              Cursor.toString(returnedPosition),
+                              Cursor.toString(Cursor.rootPosition(direction)),
                               this);
         }
 
         @Override
         public long encodedPosition()
         {
-            assert Cursor.compare(source.encodedPosition(), returnedPosition) == 0 :
-                String.format("Position changed without advance: %s -> %s\n%s",
+            long reportedPosition = source.encodedPosition();
+            assert Cursor.compare(reportedPosition, returnedPosition) == 0 :
+                String.format("Position changed without advance: %s -> %s (reported bits %016x vs expected %016x)\n%s",
                               Cursor.toString(returnedPosition),
-                              Cursor.toString(source.encodedPosition()),
+                              Cursor.toString(reportedPosition),
+                              reportedPosition,
+                              returnedPosition,
                               this);
             return returnedPosition;
         }
@@ -107,7 +109,13 @@ interface VerificationCursor
                 String.format("Cannot query content on exhausted cursor.\n%s",
                               this);
 
-            return source.content();
+            T content = source.content();
+            if (content != null)
+                assert (returnedPosition & MAY_HAVE_CONTENT_BIT) != 0 :
+                    String.format("Non-null content for position without MAY_HAVE_CONTENT_BIT: %s\n%s",
+                                  Cursor.toString(returnedPosition),
+                                  this);
+            return content;
         }
 
         @Override

--- a/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.db.tries;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.config.CassandraRelevantProperties;
+import org.apache.cassandra.utils.bytecomparable.ByteComparable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MetadataFlagsTest
+{
+    private static final long FLAG1 = 0x0002L;
+    private static final long FLAG2 = 0x0004L;
+    private static final long FLAG3 = 0x0008L;
+
+    @BeforeClass
+    public static void enableVerification()
+    {
+        CassandraRelevantProperties.TRIE_DEBUG.setBoolean(true);
+    }
+
+    @Test
+    public void testCompareIgnoresFlags()
+    {
+
+        long pos = Cursor.encode(5, 0x41, Direction.FORWARD);
+        long posWithFlag1 = pos | FLAG1;
+        long posWithFlag2 = pos | FLAG2;
+
+        assertEquals("Compare should ignore flags", 0, Cursor.compare(posWithFlag1, posWithFlag2));
+        assertEquals("Compare should ignore flags (reverse)", 0, Cursor.compare(posWithFlag2, posWithFlag1));
+        assertEquals("Compare with root should ignore flags", 0, Cursor.compare(Cursor.rootPosition(Direction.FORWARD) | FLAG1, Cursor.rootPosition(Direction.FORWARD)));
+    }
+
+    @Test
+    public void testMergeCursorUnionsFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        Cursor<Integer> c1 = new MockCursor<>(pos | FLAG1);
+        Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
+
+        MergeCursor<Integer, Cursor<Integer>> merge = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
+        
+        long expected = pos | FLAG1 | FLAG2;
+        assertEquals("MergeCursor should union flags from both sources", expected, merge.encodedPosition());
+    }
+
+    @Test
+    public void testCollectionMergeCursorUnionsFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        List<Cursor<Integer>> inputs = Arrays.asList(
+            new MockCursor<>(pos | FLAG1),
+            new MockCursor<>(pos | FLAG2),
+            new MockCursor<>(pos | FLAG3)
+        );
+
+        CollectionMergeCursor<Integer, Cursor<Integer>> merge = new CollectionMergeCursor.Plain<>(
+            Trie.throwingResolver(), Direction.FORWARD, inputs, Cursor::tailCursor
+        );
+
+        long expected = pos | FLAG1 | FLAG2 | FLAG3;
+        assertEquals("CollectionMergeCursor should union flags from all sources", expected, merge.encodedPosition());
+    }
+
+    @Test
+    public void testIntersectionCursorPreservesFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        Cursor<Integer> source = new MockCursor<>(pos | FLAG1);
+        TrieSetCursor set = new MockTrieSetCursor(pos | FLAG2, TrieSetCursor.RangeState.CONTAINED);
+
+        IntersectionCursor<Integer, Cursor<Integer>> intersect = new IntersectionCursor.Plain<>(source, set);
+        
+        // IntersectionCursor.encodedPosition returns source.encodedPosition()
+        assertEquals("IntersectionCursor should preserve source flags", pos | FLAG1, intersect.encodedPosition());
+    }
+
+    @Test
+    public void testIntersectionCursorContentBit()
+    {
+
+        long posWithContent = Cursor.rootPosition(Direction.FORWARD) | FLAG1 | Cursor.MAY_HAVE_CONTENT_BIT;
+        
+        // Plain IntersectionCursor should PRESERVE content bit even if NOT_CONTAINED
+        Cursor<Integer> source1 = new MockCursor<>(posWithContent);
+        TrieSetCursor set1 = new MockTrieSetCursor(Cursor.rootPosition(Direction.FORWARD), TrieSetCursor.RangeState.NOT_CONTAINED);
+        IntersectionCursor<Integer, Cursor<Integer>> intersect1 = new IntersectionCursor.Plain<>(source1, set1);
+        assertEquals("Plain IntersectionCursor should preserve content bit", 
+                     posWithContent, intersect1.encodedPosition());
+
+        // IntersectionCursor.PlainSlice should CLEAR content bit if NOT_CONTAINED
+        Cursor<Integer> source2 = new MockCursor<>(posWithContent);
+        TrieSetCursor set2 = new MockTrieSetCursor(Cursor.rootPosition(Direction.FORWARD), TrieSetCursor.RangeState.NOT_CONTAINED);
+        IntersectionCursor<Integer, Cursor<Integer>> intersect2 = new IntersectionCursor.PlainSlice<>(source2, set2);
+        assertEquals("PlainSlice IntersectionCursor should clear content bit when NOT_CONTAINED", 
+                     posWithContent & ~Cursor.MAY_HAVE_CONTENT_BIT, intersect2.encodedPosition());
+    }
+
+    @Test
+    public void testNegatedCursorContentBit()
+    {
+
+        long posWithContent = Cursor.encode(1, 0x41, Direction.FORWARD) | FLAG1 | Cursor.MAY_HAVE_CONTENT_BIT;
+        long posWithoutContent = posWithContent & ~Cursor.MAY_HAVE_CONTENT_BIT;
+
+        // Case 1: Source is NOT_CONTAINED -> negated should have content bit SET
+        TrieSetCursor source1 = new MockTrieSetCursor(posWithoutContent, TrieSetCursor.RangeState.NOT_CONTAINED);
+        TrieSetCursor negated1 = source1.negated();
+        // Negated root logic: if overriding == NOT_CONTAINED, it sets the bit
+        assertEquals("Negated cursor should set content bit when source is NOT_CONTAINED",
+                     posWithoutContent | Cursor.MAY_HAVE_CONTENT_BIT, negated1.encodedPosition());
+
+        // Case 2: Source is CONTAINED -> negated should have content bit CLEARED
+        TrieSetCursor source2 = new MockTrieSetCursor(posWithContent, TrieSetCursor.RangeState.CONTAINED);
+        TrieSetCursor negated2 = source2.negated();
+        assertEquals("Negated cursor should clear content bit when source is CONTAINED",
+                     posWithContent & ~Cursor.MAY_HAVE_CONTENT_BIT, negated2.encodedPosition());
+    }
+
+    @Test
+    public void testNegatedCursorPreservesFlags()
+    {
+
+        // Let's test ROOT
+        long rootPos = Cursor.rootPosition(Direction.FORWARD);
+        TrieSetCursor sourceRoot = new MockTrieSetCursor(rootPos | FLAG1, TrieSetCursor.RangeState.NOT_CONTAINED);
+        TrieSetCursor negatedRoot = sourceRoot.negated();
+        // Negated.encodedPosition for ROOT returns source.encodedPosition() | MAY_HAVE_CONTENT_BIT
+        assertEquals("Negated cursor should preserve flags at root", rootPos | FLAG1 | Cursor.MAY_HAVE_CONTENT_BIT, negatedRoot.encodedPosition());
+    }
+
+    @Test
+    public void testComplexMergeUnionsFlags()
+    {
+
+        Object[] spec1 = new Object[] { "v1", null, "v2" }; // paths "0", "2"
+        Object[] spec2 = new Object[] { null, "v3", "v4" }; // paths "1", "2"
+        
+        Trie<String> t1 = dir -> new TrieUtil.CursorFromSpec<>(spec1, dir, FLAG1);
+        Trie<String> t2 = dir -> new TrieUtil.CursorFromSpec<>(spec2, dir, FLAG2);
+        
+        Trie<String> merged = Trie.merge(Arrays.asList(t1, t2), new Trie.CollectionMergeResolver<String>() {
+            @Override public String resolve(java.util.Collection<String> contents) { return contents.iterator().next(); }
+            @Override public String resolve(String v1, String v2) { return v1; }
+        });
+        
+        Cursor<String> c = merged.cursor(Direction.FORWARD);
+        // Root
+        assertEquals("Root should have unioned flags", FLAG1 | FLAG2, c.encodedPosition() & Cursor.FLAGS_MASK);
+        
+        // Path "0" (only t1)
+        c.advance();
+        assertEquals("Path 0 should have FLAG1 and content bit", FLAG1 | Cursor.MAY_HAVE_CONTENT_BIT, c.encodedPosition() & Cursor.FLAGS_MASK);
+        
+        // Path "1" (only t2)
+        c.advance();
+        assertEquals("Path 1 should have FLAG2 and content bit", FLAG2 | Cursor.MAY_HAVE_CONTENT_BIT, c.encodedPosition() & Cursor.FLAGS_MASK);
+        
+        // Path "2" (both)
+        c.advance();
+        assertEquals("Path 2 should have unioned flags and content bit", FLAG1 | FLAG2 | Cursor.MAY_HAVE_CONTENT_BIT, c.encodedPosition() & Cursor.FLAGS_MASK);
+    }
+
+    @Test
+    public void testIntersectionPreservesFlags()
+    {
+
+        Object[] spec = new Object[] { "v1", "v2" }; // paths "0", "1"
+        Trie<String> t = dir -> new TrieUtil.CursorFromSpec<>(spec, dir, FLAG1);
+        TrieSet set = TrieSet.branch(TrieUtil.VERSION, TrieUtil.directComparable("0"));
+        
+        Trie<String> intersected = t.intersect(set);
+        Cursor<String> c = intersected.cursor(Direction.FORWARD);
+        
+        // Root
+        assertEquals("Intersected root should have source flags", FLAG1, c.encodedPosition() & Cursor.FLAGS_MASK);
+        
+        // Path "0"
+        c.advance();
+        assertEquals("Intersected path 0 should have source flags and content bit", FLAG1 | Cursor.MAY_HAVE_CONTENT_BIT, c.encodedPosition() & Cursor.FLAGS_MASK);
+    }
+
+    @Test
+    public void testMappingMergeCursorUnionsFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        Cursor<Integer> c1 = new MockCursor<>(pos | FLAG1);
+        Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
+
+        MappingMergeCursor.Plain<Integer, Integer, Integer> merge = new MappingMergeCursor.Plain<>((x, y) -> x, c1, c2);
+        
+        long expected = pos | FLAG1 | FLAG2;
+        assertEquals("MappingMergeCursor should union flags from both sources", expected, merge.encodedPosition());
+    }
+
+    @Test
+    public void testRangeIntersectionCursorPreservesFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        RangeCursor<TrieSetCursor.RangeState> source = new MockTrieSetCursor(pos | FLAG1, TrieSetCursor.RangeState.CONTAINED);
+        TrieSetCursor set = new MockTrieSetCursor(pos | FLAG2, TrieSetCursor.RangeState.CONTAINED);
+
+        RangeIntersectionCursor<TrieSetCursor.RangeState> intersect = new RangeIntersectionCursor<>(source, set);
+        
+        // RangeIntersectionCursor favors 'src' flags when matching
+        assertEquals("RangeIntersectionCursor should preserve source flags when matching", pos | FLAG1, intersect.encodedPosition());
+    }
+
+    @Test
+    public void testRangesCursorContentBit()
+    {
+
+        // Range [abc, def]
+        ByteComparable abc = TrieUtil.directComparable("abc");
+        ByteComparable def = TrieUtil.directComparable("def");
+        RangesCursor cursor = RangesCursor.create(Direction.FORWARD, TrieUtil.VERSION, true, true, abc, def);
+        
+        // Root - NOT_CONTAINED state, no content bit
+        assertEquals(TrieSetCursor.RangeState.NOT_CONTAINED, cursor.state());
+        assertTrue("Root should NOT have content bit (NOT_CONTAINED)", (cursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) == 0);
+        
+        // "a" (prefix of abc) - still NOT_CONTAINED
+        cursor.advance(); 
+        assertEquals(TrieSetCursor.RangeState.NOT_CONTAINED, cursor.state());
+        assertTrue("'a' should NOT have content bit (NOT_CONTAINED)", (cursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) == 0);
+
+        // "ab" - still NOT_CONTAINED
+        cursor.advance();
+        assertEquals(TrieSetCursor.RangeState.NOT_CONTAINED, cursor.state());
+        assertTrue("'ab' should NOT have content bit (NOT_CONTAINED)", (cursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) == 0);
+        
+        // "abc" (boundary) - START state, has content
+        cursor.advance();
+        assertEquals(TrieSetCursor.RangeState.START, cursor.state());
+        assertTrue("'abc' should have content bit (START boundary)", (cursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) != 0);
+        
+        // "d" (prefix of def, internal to range [abc, def]) - CONTAINED, no content
+        cursor.advance();
+        assertEquals(TrieSetCursor.RangeState.CONTAINED, cursor.state());
+        assertTrue("'d' should NOT have content bit (CONTAINED)", (cursor.encodedPosition() & Cursor.MAY_HAVE_CONTENT_BIT) == 0);
+    }
+
+    @Test
+    public void testFlagUnionUtility() {
+
+        long p1 = 0x1234567800000000L | 0x1L; // Depth etc, plus bit 0
+        long p2 = 0x1234567800000000L | 0x2L; // Same pos, plus bit 1
+
+        long unioned = Cursor.unionFlags(p1, p2, Cursor.FLAGS_MASK);
+        assertEquals("Flags should be unioned", 0x1234567800000003L, unioned);
+
+        long masked = Cursor.unionFlags(p1, p2, 0x1L);
+        assertEquals("Only bit 0 should be unioned if mask is 0x1", 0x1234567800000001L, masked);
+    }
+
+    @Test
+    public void testFlagIntersectionUtility()
+    {
+        long p1 = 0x1234567800000000L | FLAG1 | FLAG2; // Has FLAG1 and FLAG2
+        long p2 = 0x1234567800000000L | FLAG2 | FLAG3; // Has FLAG2 and FLAG3
+        
+        long intersected = Cursor.intersectionFlags(p1, p2, Cursor.FLAGS_MASK);
+        // Should keep only FLAG2 (common to both)
+        assertEquals("Flags should be intersected", 0x1234567800000000L | FLAG2, intersected);
+        
+        long masked = Cursor.intersectionFlags(p1, p2, FLAG1 | FLAG2);
+        // Should only intersect FLAG1 and FLAG2, FLAG3 ignored
+        assertEquals("Only specified flags should be intersected", 0x1234567800000000L | FLAG2, masked);
+    }
+
+    @Test
+    public void testDepthAdjustedCursorPreservesFlags()
+    {
+
+        long pos = Cursor.encode(1, 0x41, Direction.FORWARD) | FLAG1;
+        Cursor<Integer> source = new MockCursor<>(pos);
+        long attachmentPoint = Cursor.encode(5, 0x42, Direction.FORWARD) | FLAG2;
+        
+        DepthAdjustedCursor<Integer, Cursor<Integer>> adjusted = new DepthAdjustedCursor.Plain<>(source, attachmentPoint);
+        
+        // Depth 1 -> should add depth correction. flags from source should be preserved.
+        long expected = pos + Cursor.depthCorrectionValue(attachmentPoint);
+        assertEquals("DepthAdjustedCursor should preserve source flags at depth > 0", expected, adjusted.encodedPosition());
+        
+        // Root (depth 0)
+        source = new MockCursor<>(Cursor.rootPosition(Direction.FORWARD) | FLAG3);
+        adjusted = new DepthAdjustedCursor.Plain<>(source, attachmentPoint);
+        // Should union with attachmentPoint flags
+        long expectedRoot = Cursor.unionFlags(attachmentPoint, source.encodedPosition(), Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK);
+        assertEquals("DepthAdjustedCursor should union flags at root", expectedRoot, adjusted.encodedPosition());
+    }
+
+    @Test
+    public void testPrefixedCursorPreservesFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD) | FLAG1;
+        Cursor<Integer> source = new MockCursor<>(pos);
+        ByteComparable prefix = TrieUtil.directComparable("abc");
+        
+        PrefixedCursor.Plain<Integer> prefixed = new PrefixedCursor.Plain<>(prefix, source);
+        
+        // Advance to source root
+        prefixed.advance(); // "a"
+        prefixed.advance(); // "b"
+        prefixed.advance(); // "c"
+        
+        // Now it should be at source root. PrefixedCursor uses DepthAdjustedCursor internally when prefix is done.
+        assertEquals("PrefixedCursor should preserve FLAG1 from source", FLAG1, prefixed.encodedPosition() & FLAG1);
+    }
+
+    @Test
+    public void testRangeApplyCursorPreservesFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD) | FLAG1;
+        Cursor<Integer> data = new MockCursor<>(pos);
+        RangeCursor<TrieSetCursor.RangeState> range = new MockTrieSetCursor(Cursor.rootPosition(Direction.FORWARD) | FLAG2, TrieSetCursor.RangeState.CONTAINED);
+        
+        RangeApplyCursor<Integer, TrieSetCursor.RangeState> applied = new RangeApplyCursor<>((s, v) -> v, range, data);
+        
+        // RangeApplyCursor delegates encodedPosition to data
+        assertEquals("RangeApplyCursor should preserve data flags", pos, applied.encodedPosition());
+    }
+
+    @Test
+    public void testDeepMergeUnionsFlags()
+    {
+
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        Cursor<Integer> c1 = new MockCursor<>(pos | FLAG1);
+        Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
+        Cursor<Integer> c3 = new MockCursor<>(pos | FLAG3);
+
+        MergeCursor<Integer, Cursor<Integer>> m1 = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
+        MergeCursor<Integer, Cursor<Integer>> m2 = new MergeCursor.Plain<>(Trie.throwingResolver(), m1, c3);
+        
+        long expected = pos | FLAG1 | FLAG2 | FLAG3;
+        assertEquals("Deep MergeCursor should union flags from all ancestors", expected, m2.encodedPosition());
+
+    }
+
+    private static class MockCursor<T> implements Cursor<T>
+    {
+        long position;
+
+        MockCursor(long position) { this.position = position; }
+
+        @Override public long encodedPosition() { return position; }
+        @Override public T content() { return null; }
+        @Override public ByteComparable.Version byteComparableVersion() { return TrieUtil.VERSION; }
+        @Override public long advance() { return position; }
+        @Override public long skipTo(long p) { return position; }
+        @Override public Cursor<T> tailCursor(Direction d) { return this; }
+    }
+
+    private static class MockTrieSetCursor extends MockCursor<TrieSetCursor.RangeState> implements TrieSetCursor
+    {
+        RangeState state;
+
+        MockTrieSetCursor(long position, RangeState state)
+        {
+            super(position);
+            this.state = state;
+        }
+
+        @Override public RangeState state() { return state; }
+        @Override public TrieSetCursor tailCursor(Direction d) { return this; }
+    }
+}

--- a/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
@@ -215,7 +215,7 @@ public class MetadataFlagsTest
         Cursor<Integer> c1 = new MockCursor<>(pos | FLAG1);
         Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
 
-        MappingMergeCursor.Plain<Integer, Integer, Integer> merge = new MappingMergeCursor.Plain<>((x, y) -> x, c1, c2);
+        MergeCursor.PlainMapping<Integer, Integer, Integer> merge = new MergeCursor.PlainMapping<>((x, y) -> x, c1, c2);
         
         long expected = pos | FLAG1 | FLAG2;
         assertEquals("MappingMergeCursor should union flags from both sources", expected, merge.encodedPosition());

--- a/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/MetadataFlagsTest.java
@@ -63,7 +63,7 @@ public class MetadataFlagsTest
         Cursor<Integer> c1 = new MockCursor<>(pos | FLAG1);
         Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
 
-        MergeCursor<Integer, Cursor<Integer>> merge = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
+        MergeCursor.Plain<Integer> merge = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
         
         long expected = pos | FLAG1 | FLAG2;
         assertEquals("MergeCursor should union flags from both sources", expected, merge.encodedPosition());
@@ -314,9 +314,49 @@ public class MetadataFlagsTest
         // Root (depth 0)
         source = new MockCursor<>(Cursor.rootPosition(Direction.FORWARD) | FLAG3);
         adjusted = new DepthAdjustedCursor.Plain<>(source, attachmentPoint);
-        // Should union with attachmentPoint flags
-        long expectedRoot = Cursor.unionFlags(attachmentPoint, source.encodedPosition(), Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK);
-        assertEquals("DepthAdjustedCursor should union flags at root", expectedRoot, adjusted.encodedPosition());
+        // Should NOT union with attachmentPoint flags, only preserve source flags
+        long expectedRoot = (attachmentPoint & ~Cursor.FLAGS_MASK) | (source.encodedPosition() & (Cursor.ON_RETURN_PATH_BIT | Cursor.FLAGS_MASK));
+        assertEquals("DepthAdjustedCursor should preserve source flags at root", expectedRoot, adjusted.encodedPosition());
+    }
+
+    @Test
+    public void testUnionFlagsMatchingPositions()
+    {
+        long pos = Cursor.encode(5, 0x41, Direction.FORWARD);
+        long p1 = pos | FLAG1;
+        long p2 = pos | FLAG2;
+
+        long unioned = Cursor.unionFlagsMatchingPositions(p1, p2);
+        assertEquals("Flags should be unioned", pos | FLAG1 | FLAG2, unioned);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testUnionFlagsMatchingPositionsAssertion()
+    {
+        long p1 = Cursor.encode(5, 0x41, Direction.FORWARD);
+        long p2 = Cursor.encode(5, 0x42, Direction.FORWARD);
+
+        // This should trigger the assertion because positions don't match
+        Cursor.unionFlagsMatchingPositions(p1, p2);
+    }
+
+    @Test
+    public void testCollectionMergeCursorPositionOptimization()
+    {
+        // Test that CollectionMergeCursor correctly unions flags from multiple sources at the same position
+        long pos = Cursor.rootPosition(Direction.FORWARD);
+        List<Cursor<Integer>> inputs = Arrays.asList(
+            new MockCursor<>(pos | FLAG1),
+            new MockCursor<>(pos | FLAG2)
+        );
+
+        CollectionMergeCursor<Integer, Cursor<Integer>> merge = new CollectionMergeCursor.Plain<>(
+            Trie.throwingResolver(), Direction.FORWARD, inputs, Cursor::tailCursor
+        );
+
+        // CollectionMergeCursor.collectAndCachePosition() should have unioned the flags
+        assertEquals("CollectionMergeCursor should union flags from all sources at start", 
+                     pos | FLAG1 | FLAG2, merge.encodedPosition());
     }
 
     @Test
@@ -361,8 +401,8 @@ public class MetadataFlagsTest
         Cursor<Integer> c2 = new MockCursor<>(pos | FLAG2);
         Cursor<Integer> c3 = new MockCursor<>(pos | FLAG3);
 
-        MergeCursor<Integer, Cursor<Integer>> m1 = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
-        MergeCursor<Integer, Cursor<Integer>> m2 = new MergeCursor.Plain<>(Trie.throwingResolver(), m1, c3);
+        MergeCursor.Plain<Integer> m1 = new MergeCursor.Plain<>(Trie.throwingResolver(), c1, c2);
+        MergeCursor.Plain<Integer> m2 = new MergeCursor.Plain<>(Trie.throwingResolver(), m1, c3);
         
         long expected = pos | FLAG1 | FLAG2 | FLAG3;
         assertEquals("Deep MergeCursor should union flags from all ancestors", expected, m2.encodedPosition());

--- a/test/unit/org/apache/cassandra/db/tries/RangesTrieSetTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/RangesTrieSetTest.java
@@ -762,17 +762,10 @@ public class RangesTrieSetTest
             return new TrieSetOverRangeCursor(source.tailCursor(direction));
         }
 
-        private long applyBit(long pos)
-        {
-            if (!Cursor.isExhausted(pos) && state() != null)
-                pos |= Cursor.MAY_HAVE_CONTENT_BIT;
-            return pos;
-        }
-
         @Override
         public long encodedPosition()
         {
-            return applyBit(source.encodedPosition());
+            return source.encodedPosition();
         }
 
         @Override
@@ -784,13 +777,13 @@ public class RangesTrieSetTest
         @Override
         public long advance()
         {
-            return applyBit(source.advance());
+            return source.advance();
         }
 
         @Override
         public long skipTo(long encodedSkipPosition)
         {
-            return applyBit(source.skipTo(encodedSkipPosition));
+            return source.skipTo(encodedSkipPosition);
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/tries/RangesTrieSetTest.java
+++ b/test/unit/org/apache/cassandra/db/tries/RangesTrieSetTest.java
@@ -109,21 +109,28 @@ public class RangesTrieSetTest
                         return cursor.state();
                     }
 
+                    private long applyBit(long pos)
+                    {
+                        if (!Cursor.isExhausted(pos) && content() != null)
+                            pos |= Cursor.MAY_HAVE_CONTENT_BIT;
+                        return pos;
+                    }
+
                     public long encodedPosition()
                     {
-                        return cursor.encodedPosition();
+                        return applyBit(cursor.encodedPosition());
                     }
 
                     @Override
                     public long advance()
                     {
-                        return cursor.advance();
+                        return applyBit(cursor.advance());
                     }
 
                     @Override
                     public long skipTo(long encodedSkipPosition)
                     {
-                        return cursor.skipTo(encodedSkipPosition);
+                        return applyBit(cursor.skipTo(encodedSkipPosition));
                     }
 
                     @Override
@@ -755,10 +762,17 @@ public class RangesTrieSetTest
             return new TrieSetOverRangeCursor(source.tailCursor(direction));
         }
 
+        private long applyBit(long pos)
+        {
+            if (!Cursor.isExhausted(pos) && state() != null)
+                pos |= Cursor.MAY_HAVE_CONTENT_BIT;
+            return pos;
+        }
+
         @Override
         public long encodedPosition()
         {
-            return source.encodedPosition();
+            return applyBit(source.encodedPosition());
         }
 
         @Override
@@ -770,13 +784,13 @@ public class RangesTrieSetTest
         @Override
         public long advance()
         {
-            return source.advance();
+            return applyBit(source.advance());
         }
 
         @Override
         public long skipTo(long encodedSkipPosition)
         {
-            return source.skipTo(encodedSkipPosition);
+            return applyBit(source.skipTo(encodedSkipPosition));
         }
     }
 }

--- a/test/unit/org/apache/cassandra/db/tries/TrieUtil.java
+++ b/test/unit/org/apache/cassandra/db/tries/TrieUtil.java
@@ -552,14 +552,20 @@ public class TrieUtil
                 @Override
                 public long encodedPosition()
                 {
+                    long pos;
                     if (current == direction.select(-1, childs))
-                        return Cursor.rootPosition(direction);
+                        pos = Cursor.rootPosition(direction);
                     else if (presentContentOnReturnPath && current == direction.select(childs, -1))
-                        return Cursor.rootPosition(direction) | Cursor.ON_RETURN_PATH_BIT;
-                    else if (direction.inLoop(current, 0, childs - 1))
-                        return Cursor.encode(1, current, direction) |
+                        pos = Cursor.rootPosition(direction) | Cursor.ON_RETURN_PATH_BIT;
+                    else if (current >= 0 && current < childs)
+                        pos = Cursor.encode(1, current, direction) |
                                (presentContentOnReturnPath ? Cursor.ON_RETURN_PATH_BIT : 0);
-                    return Cursor.exhaustedPosition(direction);
+                    else
+                        return Cursor.exhaustedPosition(direction);
+
+                    if (presentContentOnReturnPath == Cursor.isOnReturnPath(pos))
+                        pos |= Cursor.MAY_HAVE_CONTENT_BIT;
+                    return pos;
                 }
 
                 @Override
@@ -567,7 +573,11 @@ public class TrieUtil
                 {
                     if (presentContentOnReturnPath != Cursor.isOnReturnPath(encodedPosition()))
                         return null;
-                    return current == childs ? -1 : current;
+                    if (current >= 0 && current < childs)
+                        return current;
+                    if (current == direction.select(-1, childs) || current == direction.select(childs, -1))
+                        return -1;
+                    return null;
                 }
 
                 @Override
@@ -622,12 +632,29 @@ public class TrieUtil
         SpecStackEntry stack;
         Direction direction;
         long position;
+        final long flagsMask;
 
         CursorFromSpec(Object[] spec, Direction direction)
         {
+            this(spec, direction, 0L);
+        }
+
+        CursorFromSpec(Object[] spec, Direction direction, long flagsMask)
+        {
             this.direction = direction;
+            this.flagsMask = flagsMask;
             stack = makeSpecStackEntry(direction, spec, null);
-            position = Cursor.rootPosition(direction);
+            position = applyFlags(Cursor.rootPosition(direction));
+        }
+
+        private long applyFlags(long pos)
+        {
+            if (Cursor.isExhausted(pos))
+                return pos;
+            pos |= flagsMask;
+            if (content() != null)
+                pos |= Cursor.MAY_HAVE_CONTENT_BIT;
+            return pos;
         }
 
         @Override
@@ -656,7 +683,8 @@ public class TrieUtil
             while (child == null);
             stack = makeSpecStackEntry(direction, child, current);
 
-            return position = encode(++depth);
+            position = applyFlags(encode(++depth));
+            return position;
         }
 
         @Override


### PR DESCRIPTION
Introduces a metadata flag in encoded cursor positions to indicate whether a node potentially carries content. This allows the trie iteration infrastructure to skip expensive content resolution calls for nodes that are guaranteed to be structural.

Those are the results of 50 benchmarks averaged: 

_Benchmark average before:_
```
Benchmark                                (BATCH)  (count)  (deletionPattern)  (deletionSpec)  (deletionsRatio)  (flush)     (memtableClass)  (partitions)  (threadCount)  (useNet)  Mode  Cnt  Score   Error  Units
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM        TrieMemtable          1000              1     false  avgt   10  8.139 ± 0.230  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM        TrieMemtable             4              1     false  avgt   10  8.158 ± 0.399  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage2          1000              1     false  avgt   10  8.113 ± 0.832  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage2             4              1     false  avgt   10  7.804 ± 1.454  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage1          1000              1     false  avgt   10  7.568 ± 1.111  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage1             4              1     false  avgt   10  7.154 ± 0.371  ms/op
```

_Benchmark average after:_ 
```
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM        TrieMemtable          1000              1     false  avgt   10  8.003 ± 0.313  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM        TrieMemtable             4              1     false  avgt   10  7.908 ± 0.643  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage2          1000              1     false  avgt   10  8.061 ± 1.140  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage2             4              1     false  avgt   10  7.601 ± 0.424  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage1          1000              1     false  avgt   10  7.458 ± 0.435  ms/op
ReadTestWidePartitions.readGreaterMatch     1000  1000000             RANDOM           EQUAL                 0    INMEM  TrieMemtableStage1             4              1     false  avgt   10  7.547 ± 0.373  ms/op
```

Flamegraphs for TrieMemtable seem to backup those results eg.
_Before:_ 
<img width="1911" height="750" alt="Screenshot 2026-02-18 at 14 33 33" src="https://github.com/user-attachments/assets/db4151ca-711f-441c-9a3e-89bdc5bed442" />
_After:_ 
<img width="1907" height="746" alt="Screenshot 2026-02-18 at 14 36 39" src="https://github.com/user-attachments/assets/b1b9cf2a-e3d0-49cb-9d52-c76043533bb5" />
